### PR TITLE
Replace Loggable protocol with @Loggable macro and #log

### DIFF
--- a/RuntimeViewerCore/Package.swift
+++ b/RuntimeViewerCore/Package.swift
@@ -44,7 +44,7 @@ extension Package.Dependency {
 let package = Package(
     name: "RuntimeViewerCore",
     platforms: [
-        .macOS(.v11), .iOS(.v14), .macCatalyst(.v14), .watchOS(.v7), .tvOS(.v14), .visionOS(.v1),
+        .macOS(.v10_15), .iOS(.v13), .macCatalyst(.v13), .watchOS(.v6), .tvOS(.v13), .visionOS(.v1),
     ],
     products: [
         .library(
@@ -143,6 +143,7 @@ let package = Package(
                 .product(name: "SwiftInterface", package: "MachOSwiftSection"),
                 .product(name: "OrderedCollections", package: "swift-collections"),
                 .product(name: "Logging", package: "swift-log"),
+                .product(name: "FoundationToolbox", package: "FrameworkToolbox"),
                 .product(name: "MemberwiseInit", package: "swift-memberwise-init-macro"),
                 .product(name: "MetaCodable", package: "MetaCodable"),
             ],

--- a/RuntimeViewerCore/Sources/RuntimeViewerCommunication/Connections/RuntimeConnectionBase.swift
+++ b/RuntimeViewerCore/Sources/RuntimeViewerCommunication/Connections/RuntimeConnectionBase.swift
@@ -1,6 +1,5 @@
 import Foundation
 import FoundationToolbox
-import OSLog
 import Combine
 
 // MARK: - RuntimeConnectionBase
@@ -20,7 +19,7 @@ import Combine
 ///
 /// - `Connection`: The underlying connection type that provides `send` and
 ///   `setMessageHandler` methods.
-class RuntimeConnectionBase<Connection: RuntimeUnderlyingConnection>: RuntimeConnection, @unchecked Sendable, Loggable {
+class RuntimeConnectionBase<Connection: RuntimeUnderlyingConnection>: RuntimeConnection, @unchecked Sendable {
     /// The underlying connection that handles actual communication.
     /// - Note: Thread-safety is managed by the underlying connection itself.
     var underlyingConnection: Connection?
@@ -111,7 +110,7 @@ class RuntimeConnectionBase<Connection: RuntimeUnderlyingConnection>: RuntimeCon
 ///
 /// This protocol abstracts the common interface needed by `RuntimeConnectionBase`
 /// to delegate message handling to different connection implementations.
-protocol RuntimeUnderlyingConnection: Sendable, Loggable {
+protocol RuntimeUnderlyingConnection: Sendable {
     /// Publisher that emits connection state changes.
     var statePublisher: AnyPublisher<RuntimeConnectionState, Never> { get }
 

--- a/RuntimeViewerCore/Sources/RuntimeViewerCommunication/RuntimeCommunicator.swift
+++ b/RuntimeViewerCore/Sources/RuntimeViewerCommunication/RuntimeCommunicator.swift
@@ -1,6 +1,5 @@
 import Foundation
 public import FoundationToolbox
-import OSLog
 
 /// Factory for creating runtime connections based on the specified source.
 ///
@@ -17,9 +16,10 @@ import OSLog
 ///     identifier: "com.example.target"
 /// ))
 /// ```
-public final class RuntimeCommunicator: Loggable {
+@Loggable
+public final class RuntimeCommunicator {
     public init() {
-        logger.debug("RuntimeCommunicator initialized")
+        #log(.debug, "RuntimeCommunicator initialized")
     }
 
     /// Establishes a connection to the specified runtime source.
@@ -30,42 +30,42 @@ public final class RuntimeCommunicator: Loggable {
     /// - Returns: A configured `RuntimeConnection` ready for communication.
     /// - Throws: An error if the connection cannot be established.
     public func connect(to source: RuntimeSource, modifier: ((RuntimeConnection) async throws -> Void)? = nil) async throws -> RuntimeConnection {
-        logger.info("Connecting to source: \(String(describing: source), privacy: .public)")
+        #log(.info, "Connecting to source: \(String(describing: source), privacy: .public)")
         switch source {
         case .local:
-            logger.error("Local connection is not supported")
+            #log(.error, "Local connection is not supported")
             throw NSError(domain: "com.RuntimeViewer.RuntimeViewerCommunication.RuntimeCommunicator", code: 1, userInfo: [NSLocalizedDescriptionKey: "Local connection is not supported"])
 
         case .remote(_, let identifier, let role):
             #if os(macOS)
             if role.isServer {
-                logger.debug("Creating XPC server connection with identifier: \(String(describing: identifier), privacy: .public)")
+                #log(.debug, "Creating XPC server connection with identifier: \(String(describing: identifier), privacy: .public)")
                 let connection = try await RuntimeXPCServerConnection(identifier: identifier, modifier: modifier)
-                logger.info("XPC server connection established")
+                #log(.info, "XPC server connection established")
                 return connection
             } else {
-                logger.debug("Creating XPC client connection with identifier: \(String(describing: identifier), privacy: .public)")
+                #log(.debug, "Creating XPC client connection with identifier: \(String(describing: identifier), privacy: .public)")
                 let connection = try await RuntimeXPCClientConnection(identifier: identifier, modifier: modifier)
-                logger.info("XPC client connection established")
+                #log(.info, "XPC client connection established")
                 return connection
             }
             #else
-            logger.error("Remote connection is not supported on this platform")
+            #log(.error, "Remote connection is not supported on this platform")
             throw NSError(domain: "com.RuntimeViewer.RuntimeViewerCommunication.RuntimeCommunicator", code: 1, userInfo: [NSLocalizedDescriptionKey: "Remote connection is not supported on this platform"])
             #endif
 
         case .bonjourClient(let endpoint):
-            logger.debug("Creating Bonjour client connection to endpoint: \(String(describing: endpoint), privacy: .public)")
+            #log(.debug, "Creating Bonjour client connection to endpoint: \(String(describing: endpoint), privacy: .public)")
             let runtimeConnection = try RuntimeNetworkClientConnection(endpoint: endpoint)
             try await modifier?(runtimeConnection)
-            logger.info("Bonjour client connection established")
+            #log(.info, "Bonjour client connection established")
             return runtimeConnection
 
         case .bonjourServer(let name, _):
-            logger.debug("Creating Bonjour server connection with name: \(name, privacy: .public)")
+            #log(.debug, "Creating Bonjour server connection with name: \(name, privacy: .public)")
             let runtimeConnection = try await RuntimeNetworkServerConnection(name: name)
             try await modifier?(runtimeConnection)
-            logger.info("Bonjour server connection established")
+            #log(.info, "Bonjour server connection established")
             return runtimeConnection
 
         case .localSocketClient(_, let identifier):
@@ -80,11 +80,11 @@ public final class RuntimeCommunicator: Loggable {
             // 4. Socket client only needs connect() - allowed even in sandboxed apps
             //
             // See RuntimeLocalSocketConnection documentation for detailed explanation.
-            logger.debug("Creating local socket server connection (business client) with identifier: \(identifier.rawValue, privacy: .public)")
+            #log(.debug, "Creating local socket server connection (business client) with identifier: \(identifier.rawValue, privacy: .public)")
             let runtimeConnection = RuntimeLocalSocketServerConnection(identifier: identifier.rawValue)
             try await runtimeConnection.start()
             try await modifier?(runtimeConnection)
-            logger.info("Local socket server connection established")
+            #log(.info, "Local socket server connection established")
             return runtimeConnection
 
         case .localSocketServer(_, let identifier):
@@ -98,23 +98,23 @@ public final class RuntimeCommunicator: Loggable {
             // 3. Socket client only needs connect() - allowed in sandboxed apps
             //
             // See RuntimeLocalSocketConnection documentation for detailed explanation.
-            logger.debug("Creating local socket client connection (business server) with identifier: \(identifier.rawValue, privacy: .public)")
+            #log(.debug, "Creating local socket client connection (business server) with identifier: \(identifier.rawValue, privacy: .public)")
             let runtimeConnection = try await RuntimeLocalSocketClientConnection(identifier: identifier.rawValue)
             try await modifier?(runtimeConnection)
-            logger.info("Local socket client connection established")
+            #log(.info, "Local socket client connection established")
             return runtimeConnection
 
         case .directTCPClient(_, let host, let port):
             #if canImport(Network)
             // Direct TCP connection to a known host:port.
             // Doesn't require NSBonjourServices or NSLocalNetworkUsageDescription.
-            logger.debug("Creating direct TCP client connection to \(host, privacy: .public):\(port, privacy: .public)")
+            #log(.debug, "Creating direct TCP client connection to \(host, privacy: .public):\(port, privacy: .public)")
             let runtimeConnection = try await RuntimeDirectTCPClientConnection(host: host, port: port)
             try await modifier?(runtimeConnection)
-            logger.info("Direct TCP client connection established")
+            #log(.info, "Direct TCP client connection established")
             return runtimeConnection
             #else
-            logger.error("Direct TCP connection is not supported on this platform")
+            #log(.error, "Direct TCP connection is not supported on this platform")
             throw NSError(domain: "com.RuntimeViewer.RuntimeViewerCommunication.RuntimeCommunicator", code: 1, userInfo: [NSLocalizedDescriptionKey: "Direct TCP connection is not supported on this platform"])
             #endif
 
@@ -122,13 +122,13 @@ public final class RuntimeCommunicator: Loggable {
             #if canImport(Network)
             // Direct TCP server listening on a port.
             // After initialization, server.host and server.port contain the actual address.
-            logger.debug("Creating direct TCP server connection on port: \(port, privacy: .public)")
+            #log(.debug, "Creating direct TCP server connection on port: \(port, privacy: .public)")
             let runtimeConnection = try await RuntimeDirectTCPServerConnection(port: port)
             try await modifier?(runtimeConnection)
-            logger.info("Direct TCP server connection established")
+            #log(.info, "Direct TCP server connection established")
             return runtimeConnection
             #else
-            logger.error("Direct TCP connection is not supported on this platform")
+            #log(.error, "Direct TCP connection is not supported on this platform")
             throw NSError(domain: "com.RuntimeViewer.RuntimeViewerCommunication.RuntimeCommunicator", code: 1, userInfo: [NSLocalizedDescriptionKey: "Direct TCP connection is not supported on this platform"])
             #endif
         }

--- a/RuntimeViewerCore/Sources/RuntimeViewerCommunication/RuntimeNetwork.swift
+++ b/RuntimeViewerCore/Sources/RuntimeViewerCommunication/RuntimeNetwork.swift
@@ -1,7 +1,6 @@
 import Foundation
 public import FoundationToolbox
 import Network
-import OSLog
 
 public enum RuntimeNetworkError: Error {
     case notConnected
@@ -61,7 +60,8 @@ public struct RuntimeNetworkEndpoint: Sendable, Codable, Equatable {
     }
 }
 
-public class RuntimeNetworkBrowser: Loggable {
+@Loggable
+public class RuntimeNetworkBrowser {
     private let browser: NWBrowser
 
     public init() {
@@ -73,7 +73,7 @@ public class RuntimeNetworkBrowser: Loggable {
 
     public func start(handler: @escaping (RuntimeNetworkEndpoint) -> Void) {
         browser.stateUpdateHandler = { newState in
-            Self.logger.info("browser.stateUpdateHandler \(String(describing: newState), privacy: .public)")
+            #log(.info, "browser.stateUpdateHandler \(String(describing: newState), privacy: .public)")
         }
         browser.browseResultsChangedHandler = { results, changes in
             for result in results {

--- a/RuntimeViewerCore/Sources/RuntimeViewerCore/Core/RuntimeObjCSection.swift
+++ b/RuntimeViewerCore/Sources/RuntimeViewerCore/Core/RuntimeObjCSection.swift
@@ -4,7 +4,6 @@ import MachOObjCSection
 import ObjCDump
 import ObjCTypeDecodeKit
 import OrderedCollections
-import OSLog
 private import RuntimeViewerCoreObjC
 import Semantic
 import Utilities
@@ -30,7 +29,8 @@ public struct ObjCGenerationOptions: Sendable, Equatable {
     public var addPropertyAttributesComments: Bool = false
 }
 
-actor RuntimeObjCSection: Loggable {
+@Loggable
+actor RuntimeObjCSection {
     enum Error: Swift.Error {
         case invalidMachOImage
         case invalidRuntimeObject
@@ -99,17 +99,17 @@ actor RuntimeObjCSection: Loggable {
     
     init(ptr: UnsafeRawPointer) async throws {
         guard let machO = MachOImage.image(for: ptr) else {
-            Self.logger.error("Failed to create MachOImage from pointer")
+            #log(.error, "Failed to create MachOImage from pointer")
             throw Error.invalidMachOImage
         }
         try await self.init(machO: machO)
     }
 
     init(imagePath: String) async throws {
-        Self.logger.info("Initializing ObjC section for image: \(imagePath, privacy: .public)")
+        #log(.info, "Initializing ObjC section for image: \(imagePath, privacy: .public)")
         let imageName = imagePath.lastPathComponent.deletingPathExtension.deletingPathExtension
         guard let machO = MachOImage(name: imageName) else {
-            Self.logger.error("Failed to create MachOImage for: \(imageName, privacy: .public)")
+            #log(.error, "Failed to create MachOImage for: \(imageName, privacy: .public)")
             throw Error.invalidMachOImage
         }
         self.machO = machO
@@ -118,14 +118,14 @@ actor RuntimeObjCSection: Loggable {
     }
 
     init(machO: MachOImage) async throws {
-        Self.logger.info("Initializing ObjC section from MachO: \(machO.imagePath, privacy: .public)")
+        #log(.info, "Initializing ObjC section from MachO: \(machO.imagePath, privacy: .public)")
         self.machO = machO
         self.imagePath = machO.imagePath
         try await prepare()
     }
 
     private func prepare() async throws {
-        logger.debug("Preparing ObjC section data")
+        #log(.debug, "Preparing ObjC section data")
         var classByName: [String: ObjCClassGroup] = [:]
         var protocolByName: [String: ObjCProtocolGroup] = [:]
         var categoryByName: [String: ObjCCategoryGroup] = [:]
@@ -238,7 +238,7 @@ actor RuntimeObjCSection: Loggable {
         categories = categoryByName
         structs = structsByName
         unions = unionsByName
-        logger.info("ObjC section prepared: \(classByName.count, privacy: .public) classes, \(protocolByName.count, privacy: .public) protocols, \(categoryByName.count, privacy: .public) categories, \(structsByName.count, privacy: .public) structs, \(unionsByName.count, privacy: .public) unions")
+        #log(.info, "ObjC section prepared: \(classByName.count, privacy: .public) classes, \(protocolByName.count, privacy: .public) protocols, \(categoryByName.count, privacy: .public) categories, \(structsByName.count, privacy: .public) structs, \(unionsByName.count, privacy: .public) unions")
     }
 
     private func infoWithSuperclasses<Class: ObjCClassProtocol>(class cls: Class, in machO: MachOImage) -> [ObjCClassInfo] {
@@ -285,7 +285,7 @@ actor RuntimeObjCSection: Loggable {
     }
 
     func allObjects() async throws -> [RuntimeObject] {
-        logger.debug("Getting all ObjC objects")
+        #log(.debug, "Getting all ObjC objects")
         var results: [RuntimeObject] = []
 
         for structName in structs.keys {
@@ -308,12 +308,12 @@ actor RuntimeObjCSection: Loggable {
             results.append(.init(name: category, displayName: category, kind: .objc(.category(.class)), secondaryKind: nil, imagePath: imagePath, children: []))
         }
 
-        logger.debug("Found \(results.count, privacy: .public) ObjC objects")
+        #log(.debug, "Found \(results.count, privacy: .public) ObjC objects")
         return results
     }
 
     func interface(for object: RuntimeObject, using options: ObjCGenerationOptions) async throws -> RuntimeObjectInterface {
-        logger.debug("Generating interface for: \(object.name, privacy: .public)")
+        #log(.debug, "Generating interface for: \(object.name, privacy: .public)")
         let name = object.withImagePath(imagePath)
         let objcDumpContext = ObjCDumpContext(options: options) { name, isStruct in
             guard let name else { return true }
@@ -526,20 +526,20 @@ actor RuntimeObjCSection: Loggable {
         default:
             break
         }
-        logger.warning("Invalid runtime object: \(object.name, privacy: .public) kind: \(String(describing: object.kind), privacy: .public)")
+        #log(.default, "Invalid runtime object: \(object.name, privacy: .public) kind: \(String(describing: object.kind), privacy: .public)")
         throw Error.invalidRuntimeObject
     }
 
     func classHierarchy(for object: RuntimeObject) async throws -> [String] {
-        logger.debug("Getting class hierarchy for: \(object.name, privacy: .public)")
+        #log(.debug, "Getting class hierarchy for: \(object.name, privacy: .public)")
         guard case .objc(.type(.class)) = object.kind,
               let classGroups = classes[object.name]
         else {
-            logger.debug("No class hierarchy found")
+            #log(.debug, "No class hierarchy found")
             return []
         }
         let hierarchy = classGroups.info.map(\.name)
-        logger.debug("Class hierarchy: \(hierarchy.count, privacy: .public) levels")
+        #log(.debug, "Class hierarchy: \(hierarchy.count, privacy: .public) levels")
         return hierarchy
     }
 }

--- a/RuntimeViewerCore/Sources/RuntimeViewerCore/RuntimeEngine.swift
+++ b/RuntimeViewerCore/Sources/RuntimeViewerCore/RuntimeEngine.swift
@@ -1,6 +1,5 @@
 import MachOKit
 public import FoundationToolbox
-import OSLog
 import RuntimeViewerCoreObjC
 public import Foundation
 public import Combine
@@ -45,7 +44,8 @@ extension RuntimeEngine {
 
 // MARK: - RuntimeEngine
 
-public actor RuntimeEngine: Loggable {
+@Loggable
+public actor RuntimeEngine {
     fileprivate enum CommandNames: String, CaseIterable {
         case imageList
         case imageNodes
@@ -108,7 +108,7 @@ public actor RuntimeEngine: Loggable {
 
     public init() {
         self.source = .local
-        logger.info("Initializing RuntimeEngine with local source")
+        #log(.info, "Initializing RuntimeEngine with local source")
 
         Task {
             await observeRuntime()
@@ -118,34 +118,34 @@ public actor RuntimeEngine: Loggable {
 
     public init(source: RuntimeSource) async throws {
         self.source = source
-        logger.info("Initializing RuntimeEngine with source: \(String(describing: source), privacy: .public)")
+        #log(.info, "Initializing RuntimeEngine with source: \(String(describing: source), privacy: .public)")
 
         if let role = source.remoteRole {
             stateSubject.send(.connecting)
 
             switch role {
             case .server:
-                logger.info("Starting as server")
+                #log(.info, "Starting as server")
                 self.connection = try await communicator.connect(to: source) { connection in
                     self.connection = connection
                     self.setupMessageHandlerForServer()
                     self.observeConnectionState(connection)
                 }
-                logger.info("Server connection established")
+                #log(.info, "Server connection established")
                 await observeRuntime()
                 stateSubject.send(.connected)
             case .client:
-                logger.info("Starting as client")
+                #log(.info, "Starting as client")
                 self.connection = try await communicator.connect(to: source) { connection in
                     self.connection = connection
                     self.setupMessageHandlerForClient()
                     self.observeConnectionState(connection)
                 }
-                logger.info("Client connected successfully")
+                #log(.info, "Client connected successfully")
                 stateSubject.send(.connected)
             }
         } else {
-            logger.debug("No remote role, observing local runtime")
+            #log(.debug, "No remote role, observing local runtime")
             await observeRuntime()
             stateSubject.send(.localOnly)
         }
@@ -180,11 +180,11 @@ public actor RuntimeEngine: Loggable {
         connectionStateCancellable = nil
         connection?.stop()
         stateSubject.send(.disconnected(error: nil))
-        logger.info("RuntimeEngine stopped")
+        #log(.info, "RuntimeEngine stopped")
     }
 
     private func setupMessageHandlerForServer() {
-        logger.debug("Setting up server message handlers")
+        #log(.debug, "Setting up server message handlers")
         setMessageHandlerBinding(forName: .isImageLoaded, of: self) { $0.isImageLoaded(path:) }
         setMessageHandlerBinding(forName: .loadImage, of: self) { $0.loadImage(at:) }
         setMessageHandlerBinding(forName: .imageNameOfClassName, of: self) { $0.imageName(ofObjectName:) }
@@ -192,20 +192,20 @@ public actor RuntimeEngine: Loggable {
         setMessageHandlerBinding(forName: .runtimeObjectsInImage, of: self) { $0.objects(in:) }
         setMessageHandlerBinding(forName: .runtimeInterfaceForRuntimeObjectInImageWithOptions, of: self) { $0.interface(for:) }
         setMessageHandlerBinding(forName: .runtimeObjectHierarchy, of: self) { $0.hierarchy(for:) }
-        logger.debug("Server message handlers setup complete")
+        #log(.debug, "Server message handlers setup complete")
     }
 
     private func setupMessageHandlerForClient() {
-        logger.debug("Setting up client message handlers")
+        #log(.debug, "Setting up client message handlers")
         setMessageHandlerBinding(forName: .imageList) { $0.imageList = $1 }
         setMessageHandlerBinding(forName: .imageNodes) { $0.imageNodes = $1 }
         setMessageHandlerBinding(forName: .reloadData) { $0.reloadDataSubject.send() }
-        logger.debug("Client message handlers setup complete")
+        #log(.debug, "Client message handlers setup complete")
     }
 
     private func setMessageHandlerBinding<Object: AnyObject, Request: Codable>(forName name: CommandNames, of object: Object, to function: @escaping (Object) -> ((Request) async throws -> Void)) {
         guard let connection else {
-            logger.warning("Connection is nil when setting message handler for \(name.commandName, privacy: .public)")
+            #log(.default, "Connection is nil when setting message handler for \(name.commandName, privacy: .public)")
             return
         }
         connection.setMessageHandler(name: name.commandName) { [unowned object] (request: Request) in
@@ -215,7 +215,7 @@ public actor RuntimeEngine: Loggable {
 
     private func setMessageHandlerBinding<Object: AnyObject, Request: Codable, Response: Codable>(forName name: CommandNames, of object: Object, to function: @escaping (Object) -> ((Request) async throws -> Response)) {
         guard let connection else {
-            logger.warning("Connection is nil when setting message handler for \(name.commandName, privacy: .public)")
+            #log(.default, "Connection is nil when setting message handler for \(name.commandName, privacy: .public)")
             return
         }
         connection.setMessageHandler(name: name.commandName) { [unowned object] (request: Request) -> Response in
@@ -226,7 +226,7 @@ public actor RuntimeEngine: Loggable {
 
     private func setMessageHandlerBinding<Response: Codable>(forName name: CommandNames, perform: @escaping (isolated RuntimeEngine, Response) async throws -> Void) {
         guard let connection else {
-            logger.warning("Connection is nil when setting message handler for \(name.commandName, privacy: .public)")
+            #log(.default, "Connection is nil when setting message handler for \(name.commandName, privacy: .public)")
             return
         }
         connection.setMessageHandler(name: name.commandName) { [weak self] (response: Response) in
@@ -237,7 +237,7 @@ public actor RuntimeEngine: Loggable {
 
     private func setMessageHandlerBinding(forName name: CommandNames, perform: @escaping (isolated RuntimeEngine) async throws -> Void) {
         guard let connection else {
-            logger.warning("Connection is nil when setting message handler for \(name.commandName, privacy: .public)")
+            #log(.default, "Connection is nil when setting message handler for \(name.commandName, privacy: .public)")
             return
         }
         connection.setMessageHandler(name: name.commandName) { [weak self] in
@@ -247,29 +247,29 @@ public actor RuntimeEngine: Loggable {
     }
 
     public func reloadData(isReloadImageNodes: Bool) {
-        logger.info("Reloading data, isReloadImageNodes=\(isReloadImageNodes, privacy: .public)")
+        #log(.info, "Reloading data, isReloadImageNodes=\(isReloadImageNodes, privacy: .public)")
         imageList = DyldUtilities.imageNames()
-        logger.debug("Loaded \(self.imageList.count, privacy: .public) images")
+        #log(.debug, "Loaded \(self.imageList.count, privacy: .public) images")
         if isReloadImageNodes {
             imageNodes = [DyldUtilities.dyldSharedCacheImageRootNode, DyldUtilities.otherImageRootNode]
-            logger.debug("Reloaded image nodes")
+            #log(.debug, "Reloaded image nodes")
         }
         sendRemoteDataIfNeeded(isReloadImageNodes: isReloadImageNodes)
-        logger.info("Data reload complete")
+        #log(.info, "Data reload complete")
     }
 
     private func observeRuntime() async {
-        logger.info("Starting runtime observation")
+        #log(.info, "Starting runtime observation")
         imageList = DyldUtilities.imageNames()
-        logger.debug("Initial image list contains \(self.imageList.count, privacy: .public) images")
+        #log(.debug, "Initial image list contains \(self.imageList.count, privacy: .public) images")
 
         await Task.detached {
             await self.setImageNodes([DyldUtilities.dyldSharedCacheImageRootNode, DyldUtilities.otherImageRootNode])
         }.value
-        logger.debug("Image nodes initialized")
+        #log(.debug, "Image nodes initialized")
 
         sendRemoteDataIfNeeded(isReloadImageNodes: true)
-        logger.info("Runtime observation started")
+        #log(.info, "Runtime observation started")
     }
 
     private func setImageNodes(_ imageNodes: [RuntimeImageNode]) async {
@@ -283,26 +283,26 @@ public actor RuntimeEngine: Loggable {
     private func sendRemoteDataIfNeeded(isReloadImageNodes: Bool) {
         Task {
             guard let role = source.remoteRole, role.isServer, let connection else {
-                logger.debug("No remote connection, sending local reload notification")
+                #log(.debug, "No remote connection, sending local reload notification")
                 reloadDataSubject.send()
                 return
             }
-            logger.debug("Sending remote data to client")
+            #log(.debug, "Sending remote data to client")
             try await connection.sendMessage(name: .imageList, request: imageList)
             if isReloadImageNodes {
                 try await connection.sendMessage(name: .imageNodes, request: imageNodes)
             }
             try await connection.sendMessage(name: .reloadData)
-            logger.debug("Remote data sent successfully")
+            #log(.debug, "Remote data sent successfully")
         }
     }
 
     private func _objects(in image: String) async throws -> [RuntimeObject] {
-        logger.debug("Getting objects in image: \(image, privacy: .public)")
+        #log(.debug, "Getting objects in image: \(image, privacy: .public)")
         let image = DyldUtilities.patchImagePathForDyld(image)
         let objcObjects = try await _objcSection(for: image).allObjects()
         let swiftObjects = try await _swiftSection(for: image).allObjects()
-        logger.debug("Found \(objcObjects.count, privacy: .public) ObjC and \(swiftObjects.count, privacy: .public) Swift objects")
+        #log(.debug, "Found \(objcObjects.count, privacy: .public) ObjC and \(swiftObjects.count, privacy: .public) Swift objects")
         return objcObjects + swiftObjects
     }
 
@@ -336,49 +336,49 @@ public actor RuntimeEngine: Loggable {
 
     private func _objcSection(for imagePath: String) async throws -> RuntimeObjCSection {
         if let objcSection = imageToObjCSection[imagePath] {
-            logger.debug("Using cached ObjC section for: \(imagePath, privacy: .public)")
+            #log(.debug, "Using cached ObjC section for: \(imagePath, privacy: .public)")
             return objcSection
         } else {
-            logger.debug("Creating ObjC section for: \(imagePath, privacy: .public)")
+            #log(.debug, "Creating ObjC section for: \(imagePath, privacy: .public)")
             let objcSection = try await RuntimeObjCSection(imagePath: imagePath)
             imageToObjCSection[imagePath] = objcSection
-            logger.debug("ObjC section created and cached")
+            #log(.debug, "ObjC section created and cached")
             return objcSection
         }
     }
 
     private func _objcSection(forName name: RuntimeObjCName) async -> RuntimeObjCSection? {
-        logger.debug("Looking up ObjC section for name: \(String(describing: name), privacy: .public)")
+        #log(.debug, "Looking up ObjC section for name: \(String(describing: name), privacy: .public)")
         do {
             guard let machO = MachOImage.image(forName: name) else {
-                logger.debug("No MachO image found for name")
+                #log(.debug, "No MachO image found for name")
                 return nil
             }
 
             if let existObjCSection = imageToObjCSection[machO.imagePath] {
-                logger.debug("Using cached ObjC section")
+                #log(.debug, "Using cached ObjC section")
                 return existObjCSection
             }
 
-            logger.debug("Creating ObjC section from MachO: \(machO.imagePath, privacy: .public)")
+            #log(.debug, "Creating ObjC section from MachO: \(machO.imagePath, privacy: .public)")
             let objcSection = try await RuntimeObjCSection(machO: machO)
             imageToObjCSection[machO.imagePath] = objcSection
             return objcSection
         } catch {
-            logger.error("Failed to create ObjC section: \(error, privacy: .public)")
+            #log(.error, "Failed to create ObjC section: \(error, privacy: .public)")
             return nil
         }
     }
 
     private func _swiftSection(for imagePath: String) async throws -> RuntimeSwiftSection {
         if let swiftSection = imageToSwiftSection[imagePath] {
-            logger.debug("Using cached Swift section for: \(imagePath, privacy: .public)")
+            #log(.debug, "Using cached Swift section for: \(imagePath, privacy: .public)")
             return swiftSection
         } else {
-            logger.debug("Creating Swift section for: \(imagePath, privacy: .public)")
+            #log(.debug, "Creating Swift section for: \(imagePath, privacy: .public)")
             let swiftSection = try await RuntimeSwiftSection(imagePath: imagePath)
             imageToSwiftSection[imagePath] = swiftSection
-            logger.debug("Swift section created and cached")
+            #log(.debug, "Swift section created and cached")
             return swiftSection
         }
     }

--- a/RuntimeViewerCore/Sources/RuntimeViewerCore/Utils/DyldUtilities.swift
+++ b/RuntimeViewerCore/Sources/RuntimeViewerCore/Utils/DyldUtilities.swift
@@ -3,13 +3,13 @@ package import Foundation
 import FoundationToolbox
 import MachO.dyld
 import MachOKit
-import OSLog
 
 public struct DyldOpenError: Error {
     public let message: String?
 }
 
-package enum DyldUtilities: Loggable {
+@Loggable
+package enum DyldUtilities {
     package static let addImageNotification = Notification.Name("com.JH.RuntimeViewerCore.DyldRegisterObserver.addImageNotification")
 
     package static let removeImageNotification = Notification.Name("com.JH.RuntimeViewerCore.DyldRegisterObserver.removeImageNotification")
@@ -22,7 +22,7 @@ package enum DyldUtilities: Loggable {
     }
 
     package static func observeDyldRegisterEvents() {
-        logger.info("Registering dyld image event observers")
+        #log(.info, "Registering dyld image event observers")
         _dyld_register_func_for_add_image { _, _ in
             NotificationCenter.default.post(name: Self.addImageNotification, object: nil)
         }
@@ -30,7 +30,7 @@ package enum DyldUtilities: Loggable {
         _dyld_register_func_for_remove_image { _, _ in
             NotificationCenter.default.post(name: Self.removeImageNotification, object: nil)
         }
-        logger.debug("Dyld event observers registered")
+        #log(.debug, "Dyld event observers registered")
     }
 
     package static func imageNames() -> [String] {
@@ -40,7 +40,7 @@ package enum DyldUtilities: Loggable {
             .prefix { $0 != nil }
             .compactMap { $0 }
             .map { String(cString: $0) })
-        logger.debug("Retrieved \(names.count, privacy: .public) image names from dyld")
+        #log(.debug, "Retrieved \(names.count, privacy: .public) image names from dyld")
         return names
     }
 
@@ -52,17 +52,17 @@ package enum DyldUtilities: Loggable {
     }
     
     package static func loadImage(at path: String) throws {
-        logger.info("Loading image at path: \(path, privacy: .public)")
+        #log(.info, "Loading image at path: \(path, privacy: .public)")
         try path.withCString { cString in
             let handle = dlopen(cString, RTLD_LAZY)
             // get the error and copy it into an object we control since the error is shared
             let errPtr = dlerror()
             let errStr = errPtr.map { String(cString: $0) }
             guard handle != nil else {
-                logger.error("Failed to load image: \(errStr ?? "unknown error", privacy: .public)")
+                #log(.error, "Failed to load image: \(errStr ?? "unknown error", privacy: .public)")
                 throw DyldOpenError(message: errStr)
             }
-            logger.info("Image loaded successfully")
+            #log(.info, "Image loaded successfully")
         }
     }
 
@@ -70,40 +70,40 @@ package enum DyldUtilities: Loggable {
     
     private static func dyldSharedCacheImagePaths() -> [String] {
         if let dyldSharedCacheImagePathsCache {
-            logger.debug("Using cached dyld shared cache image paths (\(dyldSharedCacheImagePathsCache.count, privacy: .public) paths)")
+            #log(.debug, "Using cached dyld shared cache image paths (\(dyldSharedCacheImagePathsCache.count, privacy: .public) paths)")
             return dyldSharedCacheImagePathsCache
         }
-        logger.debug("Loading dyld shared cache image paths")
+        #log(.debug, "Loading dyld shared cache image paths")
         guard let dyldCache = DyldCacheLoaded.current, let imageInfos = dyldCache.imageInfos else {
-            logger.warning("Failed to load dyld shared cache or image infos")
+            #log(.default, "Failed to load dyld shared cache or image infos")
             return []
         }
         let results = imageInfos.compactMap { $0.path(in: dyldCache) }
         dyldSharedCacheImagePathsCache = results
-        logger.info("Loaded \(results.count, privacy: .public) dyld shared cache image paths")
+        #log(.info, "Loaded \(results.count, privacy: .public) dyld shared cache image paths")
         return results
     }
 
     package static func invalidDyldSharedCacheImagePathsCache() {
-        logger.debug("Invalidating dyld shared cache image paths cache")
+        #log(.debug, "Invalidating dyld shared cache image paths cache")
         dyldSharedCacheImagePathsCache = nil
     }
 
     package static var dyldSharedCacheImageRootNode: RuntimeImageNode {
-        logger.debug("Building dyld shared cache image root node")
+        #log(.debug, "Building dyld shared cache image root node")
         let paths = dyldSharedCacheImagePaths()
         let node = RuntimeImageNode.rootNode(for: paths, name: "Dyld Shared Cache")
-        logger.debug("Built dyld shared cache root node with \(paths.count, privacy: .public) images")
+        #log(.debug, "Built dyld shared cache root node with \(paths.count, privacy: .public) images")
         return node
     }
 
     package static var otherImageRootNode: RuntimeImageNode {
-        logger.debug("Building other image root node")
+        #log(.debug, "Building other image root node")
         let dyldSharedCacheImagePaths = dyldSharedCacheImagePaths()
         let allImagePaths = imageNames()
         let otherImagePaths = allImagePaths.filter { !dyldSharedCacheImagePaths.contains($0) }
         let node = RuntimeImageNode.rootNode(for: otherImagePaths, name: "Others")
-        logger.debug("Built other images root node with \(otherImagePaths.count, privacy: .public) images")
+        #log(.debug, "Built other images root node with \(otherImagePaths.count, privacy: .public) images")
         return node
     }
 }


### PR DESCRIPTION
## Summary
- Migrate from the `Loggable` protocol to `@Loggable` macro and replace all `logger.xxx()` calls with `#log(.level, ...)` freestanding macro from FoundationToolbox
- Lower minimum deployment target from macOS 11/iOS 14 to macOS 10.15/iOS 13, as the macros handle `os.Logger` availability checks internally

## Test plan
- [ ] Verify the app builds successfully on macOS
- [ ] Verify logging output is correct at runtime
- [ ] Confirm deployment target is macOS 10.15

🤖 Generated with [Claude Code](https://claude.com/claude-code)