### PR TITLE
fix: Add platform guard to VisualEffectView for iOS compatibility

### DIFF
--- a/RuntimeViewerPackages/Sources/RuntimeViewerUI/SwiftUI/VisualEffectView.swift
+++ b/RuntimeViewerPackages/Sources/RuntimeViewerUI/SwiftUI/VisualEffectView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 /// A SwiftUI Wrapper for `NSVisualEffectView`
 ///
 /// ## Usage
@@ -63,3 +64,4 @@ public struct VisualEffectView: NSViewRepresentable {
         }
     }
 }
+#endif


### PR DESCRIPTION
## Summary
- Wrap `VisualEffectView` (which uses `NSVisualEffectView`/`NSViewRepresentable`) in `#if canImport(AppKit) && !targetEnvironment(macCatalyst)` guard
- Fixes iOS build failure since these AppKit types are unavailable on iOS/tvOS/visionOS

## Test plan
- [x] Build and run `RuntimeViewer iOS` scheme on iPhone 16 Pro Simulator (iOS 18.5)
- [ ] Verify macOS build still succeeds