### PR TITLE
ci: Add GitHub Actions release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,103 @@
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: macos-15
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Clone sibling dependencies
+        run: |
+          cd ..
+          git clone --depth 1 https://github.com/MxIris-Reverse-Engineering/MachOKit.git
+          git clone --depth 1 https://github.com/MxIris-Reverse-Engineering/MachOObjCSection.git
+          git clone --depth 1 https://github.com/MxIris-Reverse-Engineering/MachOSwiftSection.git
+
+      # TODO: The sibling repos use branch: "main" in Package.swift remote
+      # fallbacks. They should be pinned to specific revisions or tags for
+      # reproducible CI builds.
+
+      - name: Select Xcode 26.2
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '26.2'
+
+      - name: Resolve package dependencies
+        run: |
+          xcodebuild -resolvePackageDependencies \
+            -workspace RuntimeViewer.xcworkspace \
+            -scheme "RuntimeViewer iOS" \
+            -derivedDataPath ./DerivedData \
+            -skipPackagePluginValidation \
+            -skipMacroValidation
+
+      # TODO: macOS build requires signing key and Catalyst helper.
+      # Uncomment once signing is set up on CI.
+      #
+      # - name: Build Catalyst helper
+      #   run: |
+      #     xcodebuild build \
+      #       -workspace RuntimeViewer.xcworkspace \
+      #       -scheme RuntimeViewerCatalystHelper \
+      #       -configuration Release \
+      #       -destination 'generic/platform=macOS,variant=Mac Catalyst' \
+      #       -derivedDataPath ./DerivedData \
+      #       -skipPackagePluginValidation \
+      #       -skipMacroValidation \
+      #       CODE_SIGNING_ALLOWED=NO \
+      #       SWIFT_WHOLE_MODULE_OPTIMIZATION=NO \
+      #       GCC_OPTIMIZATION_LEVEL=0
+      #     cp -R ./DerivedData/Build/Products/Release-maccatalyst/RuntimeViewerCatalystHelper.app \
+      #       ./RuntimeViewerUsingAppKit/RuntimeViewerCatalystHelper.app
+      #
+      # - name: Build macOS app
+      #   run: |
+      #     xcodebuild build \
+      #       -workspace RuntimeViewer.xcworkspace \
+      #       -scheme "RuntimeViewer macOS" \
+      #       -configuration Release \
+      #       -destination 'generic/platform=macOS' \
+      #       -derivedDataPath ./DerivedData \
+      #       -skipPackagePluginValidation \
+      #       -skipMacroValidation \
+      #       ARCHS=arm64 \
+      #       CODE_SIGNING_ALLOWED=NO \
+      #       SWIFT_WHOLE_MODULE_OPTIMIZATION=NO \
+      #       GCC_OPTIMIZATION_LEVEL=0 \
+      #       ASSETCATALOG_COMPILER_APPICON_NAME=""
+
+      - name: Build iOS Simulator app
+        run: |
+          xcodebuild build \
+            -workspace RuntimeViewer.xcworkspace \
+            -scheme "RuntimeViewer iOS" \
+            -configuration Release \
+            -destination 'generic/platform=iOS Simulator' \
+            -derivedDataPath ./DerivedData \
+            -skipPackagePluginValidation \
+            -skipMacroValidation \
+            CODE_SIGNING_ALLOWED=NO
+
+      - name: Package artifacts
+        run: |
+          cd ./DerivedData/Build/Products/Release-iphonesimulator
+          /usr/bin/ditto -c -k --keepParent RuntimeViewer.app \
+            "$GITHUB_WORKSPACE/RuntimeViewer-iOS-Simulator.zip"
+
+      - name: Create Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            --title "RuntimeViewer ${{ github.ref_name }}" \
+            --generate-notes \
+            RuntimeViewer-iOS-Simulator.zip

--- a/RuntimeViewerPackages/Package.swift
+++ b/RuntimeViewerPackages/Package.swift
@@ -462,7 +462,7 @@ let package = Package(
             dependencies: [
                 "RuntimeViewerServiceHelper",
                 .product(name: "RuntimeViewerCommunication", package: "RuntimeViewerCore"),
-                .product(name: "SwiftyXPC", package: "SwiftyXPC"),
+                .product(name: "SwiftyXPC", package: "SwiftyXPC", condition: .when(platforms: appkitPlatforms)),
                 .product(name: "Dependencies", package: "swift-dependencies"),
             ]
         ),


### PR DESCRIPTION
## Summary
- Add a GitHub Actions workflow that builds and releases the iOS Simulator app when a version tag (`v*`) is pushed
- macOS build steps are commented out until signing is set up on CI
- Fix missing platform guard on SwiftyXPC dependency in `RuntimeViewerHelperClient`, which caused iOS builds to fail

## Test plan
- [x] Verified iOS Simulator build succeeds on CI ([run](https://github.com/Kyle-Ye/RuntimeViewer/actions/runs/22019846681))
- [x] Release creation works (failed only due to pre-existing tag from test iterations)
- [ ] Push a `v*` tag on upstream to create a release with iOS Simulator artifact