### PR TITLE
ci: Add full macOS release workflow with signing and notarization

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,11 +5,22 @@ on:
     tags: ['v*']
   workflow_dispatch:
 
+# Required GitHub Secrets:
+#   CERTIFICATE_P12       - Base64-encoded Developer ID Application certificate (.p12)
+#   CERTIFICATE_PASSWORD  - Password for the .p12 certificate
+#   NOTARY_KEY_ID         - App Store Connect API Key ID
+#   NOTARY_ISSUER_ID      - App Store Connect API Issuer ID
+#   NOTARY_AUTH_KEY       - App Store Connect API Key content (.p8)
+
 jobs:
   release:
     runs-on: macos-15
     permissions:
       contents: write
+
+    env:
+      WORKSPACE: RuntimeViewer.xcworkspace
+      BUILD_PATH: ./Products/Archives
 
     steps:
       - name: Checkout
@@ -31,54 +42,137 @@ jobs:
         with:
           xcode-version: '26.2'
 
+      - name: Import code signing certificate
+        env:
+          CERTIFICATE_P12: ${{ secrets.CERTIFICATE_P12 }}
+          CERTIFICATE_PASSWORD: ${{ secrets.CERTIFICATE_PASSWORD }}
+        run: |
+          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+          KEYCHAIN_PASSWORD=$(openssl rand -base64 32)
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          echo "$CERTIFICATE_P12" | base64 --decode > "$RUNNER_TEMP/certificate.p12"
+          security import "$RUNNER_TEMP/certificate.p12" \
+            -P "$CERTIFICATE_PASSWORD" \
+            -A -t cert -f pkcs12 \
+            -k "$KEYCHAIN_PATH"
+
+          security list-keychain -d user -s "$KEYCHAIN_PATH"
+          security set-key-partition-list -S apple-tool:,apple: \
+            -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
       - name: Resolve package dependencies
         run: |
           xcodebuild -resolvePackageDependencies \
-            -workspace RuntimeViewer.xcworkspace \
-            -scheme "RuntimeViewer iOS" \
-            -derivedDataPath ./DerivedData \
+            -workspace $WORKSPACE \
+            -scheme "RuntimeViewer macOS" \
             -skipPackagePluginValidation \
             -skipMacroValidation
 
-      # TODO: macOS build requires signing key and Catalyst helper.
-      # Uncomment once signing is set up on CI.
-      #
-      # - name: Build Catalyst helper
-      #   run: |
-      #     xcodebuild build \
-      #       -workspace RuntimeViewer.xcworkspace \
-      #       -scheme RuntimeViewerCatalystHelper \
-      #       -configuration Release \
-      #       -destination 'generic/platform=macOS,variant=Mac Catalyst' \
-      #       -derivedDataPath ./DerivedData \
-      #       -skipPackagePluginValidation \
-      #       -skipMacroValidation \
-      #       CODE_SIGNING_ALLOWED=NO \
-      #       SWIFT_WHOLE_MODULE_OPTIMIZATION=NO \
-      #       GCC_OPTIMIZATION_LEVEL=0
-      #     cp -R ./DerivedData/Build/Products/Release-maccatalyst/RuntimeViewerCatalystHelper.app \
-      #       ./RuntimeViewerUsingAppKit/RuntimeViewerCatalystHelper.app
-      #
-      # - name: Build macOS app
-      #   run: |
-      #     xcodebuild build \
-      #       -workspace RuntimeViewer.xcworkspace \
-      #       -scheme "RuntimeViewer macOS" \
-      #       -configuration Release \
-      #       -destination 'generic/platform=macOS' \
-      #       -derivedDataPath ./DerivedData \
-      #       -skipPackagePluginValidation \
-      #       -skipMacroValidation \
-      #       ARCHS=arm64 \
-      #       CODE_SIGNING_ALLOWED=NO \
-      #       SWIFT_WHOLE_MODULE_OPTIMIZATION=NO \
-      #       GCC_OPTIMIZATION_LEVEL=0 \
-      #       ASSETCATALOG_COMPILER_APPICON_NAME=""
+      # ── macOS: Archive & Export Catalyst Helper ──
+
+      - name: Archive Catalyst helper
+        run: |
+          xcodebuild archive \
+            -workspace $WORKSPACE \
+            -scheme RuntimeViewerCatalystHelper \
+            -configuration Release \
+            -destination 'generic/platform=macOS,variant=Mac Catalyst' \
+            -archivePath $BUILD_PATH/RuntimeViewerCatalystHelper.xcarchive \
+            -skipPackagePluginValidation \
+            -skipMacroValidation \
+            CURRENT_PROJECT_VERSION=$(date +"%Y%m%d.%H.%M")
+
+      - name: Export Catalyst helper
+        run: |
+          EXPORT_PATH=RuntimeViewerUsingAppKit
+
+          rm -rf "$EXPORT_PATH/RuntimeViewerCatalystHelper.app"
+
+          xcodebuild -exportArchive \
+            -archivePath $BUILD_PATH/RuntimeViewerCatalystHelper.xcarchive \
+            -configuration Release \
+            -exportPath "$EXPORT_PATH" \
+            -exportOptionsPlist ArchiveExportConfig-Catalyst.plist \
+            -quiet
+
+          rm -f "$EXPORT_PATH/Packaging.log"
+          rm -f "$EXPORT_PATH/DistributionSummary.plist"
+          rm -f "$EXPORT_PATH/ExportOptions.plist"
+
+      # ── macOS: Archive & Export Main App ──
+
+      - name: Archive macOS app
+        run: |
+          xcodebuild archive \
+            -workspace $WORKSPACE \
+            -scheme "RuntimeViewer macOS" \
+            -configuration Release \
+            -destination 'generic/platform=macOS' \
+            -archivePath $BUILD_PATH/RuntimeViewer.xcarchive \
+            -skipPackagePluginValidation \
+            -skipMacroValidation \
+            CURRENT_PROJECT_VERSION=$(date +"%Y%m%d.%H.%M")
+
+      - name: Export macOS app
+        run: |
+          EXPORT_PATH=$BUILD_PATH/Products/Export
+          rm -rf "$EXPORT_PATH"
+
+          xcodebuild -exportArchive \
+            -archivePath $BUILD_PATH/RuntimeViewer.xcarchive \
+            -configuration Release \
+            -exportPath "$EXPORT_PATH" \
+            -exportOptionsPlist ArchiveExportConfig.plist \
+            -quiet
+
+          if [ ! -d "$EXPORT_PATH/RuntimeViewer.app" ]; then
+            echo "Error: App not found at $EXPORT_PATH/RuntimeViewer.app"
+            exit 1
+          fi
+
+      # ── macOS: Notarization ──
+
+      - name: Notarize macOS app
+        env:
+          NOTARY_KEY_ID: ${{ secrets.NOTARY_KEY_ID }}
+          NOTARY_ISSUER_ID: ${{ secrets.NOTARY_ISSUER_ID }}
+          NOTARY_AUTH_KEY: ${{ secrets.NOTARY_AUTH_KEY }}
+        run: |
+          if [ -z "$NOTARY_KEY_ID" ]; then
+            echo "Notarization secrets not configured, skipping."
+            exit 0
+          fi
+
+          EXPORT_PATH=$BUILD_PATH/Products/Export
+          APP_PATH="$EXPORT_PATH/RuntimeViewer.app"
+          ZIP_PATH="$EXPORT_PATH/RuntimeViewer-notarize.zip"
+
+          AUTH_KEY_PATH="$RUNNER_TEMP/AuthKey_${NOTARY_KEY_ID}.p8"
+          echo "$NOTARY_AUTH_KEY" > "$AUTH_KEY_PATH"
+
+          echo "Zipping app for notarization..."
+          /usr/bin/ditto -c -k --keepParent "$APP_PATH" "$ZIP_PATH"
+
+          echo "Submitting to Apple Notary Service..."
+          xcrun notarytool submit "$ZIP_PATH" \
+            --key "$AUTH_KEY_PATH" \
+            --key-id "$NOTARY_KEY_ID" \
+            --issuer "$NOTARY_ISSUER_ID" \
+            --wait
+
+          echo "Stapling notarization ticket..."
+          xcrun stapler staple "$APP_PATH"
+
+      # ── iOS Simulator ──
 
       - name: Build iOS Simulator app
         run: |
           xcodebuild build \
-            -workspace RuntimeViewer.xcworkspace \
+            -workspace $WORKSPACE \
             -scheme "RuntimeViewer iOS" \
             -configuration Release \
             -destination 'generic/platform=iOS Simulator' \
@@ -87,8 +181,15 @@ jobs:
             -skipMacroValidation \
             CODE_SIGNING_ALLOWED=NO
 
+      # ── Package & Release ──
+
       - name: Package artifacts
         run: |
+          EXPORT_PATH=$BUILD_PATH/Products/Export
+
+          /usr/bin/ditto -c -k --keepParent "$EXPORT_PATH/RuntimeViewer.app" \
+            RuntimeViewer-macOS.zip
+
           cd ./DerivedData/Build/Products/Release-iphonesimulator
           /usr/bin/ditto -c -k --keepParent RuntimeViewer.app \
             "$GITHUB_WORKSPACE/RuntimeViewer-iOS-Simulator.zip"
@@ -100,4 +201,12 @@ jobs:
           gh release create "${{ github.ref_name }}" \
             --title "RuntimeViewer ${{ github.ref_name }}" \
             --generate-notes \
+            RuntimeViewer-macOS.zip \
             RuntimeViewer-iOS-Simulator.zip
+
+      - name: Clean up keychain
+        if: always()
+        run: |
+          if [ -f "$RUNNER_TEMP/app-signing.keychain-db" ]; then
+            security delete-keychain "$RUNNER_TEMP/app-signing.keychain-db"
+          fi


### PR DESCRIPTION
## Summary
- Migrate `ArchiveScript.sh` build flow into the GitHub Actions release workflow
- Import Developer ID Application certificate via temporary keychain for code signing
- Archive & export Catalyst helper and macOS app using `xcodebuild archive` / `-exportArchive`
- Optionally notarize the macOS app using App Store Connect API key (`notarytool`)
- Upload both `RuntimeViewer-macOS.zip` and `RuntimeViewer-iOS-Simulator.zip` to the GitHub release
- Clean up temporary keychain on workflow completion

## Required GitHub Secrets
| Secret | Description |
|---|---|
| `CERTIFICATE_P12` | Base64-encoded Developer ID Application certificate (.p12) |
| `CERTIFICATE_PASSWORD` | Password for the .p12 certificate |
| `NOTARY_KEY_ID` | App Store Connect API Key ID (optional) |
| `NOTARY_ISSUER_ID` | App Store Connect API Issuer ID (optional) |
| `NOTARY_AUTH_KEY` | App Store Connect API Key content, .p8 (optional) |

## Test plan
- [ ] Configure signing secrets and trigger a workflow_dispatch run
- [ ] Verify Catalyst helper archives and exports successfully
- [ ] Verify macOS app archives, exports, and the .app is present in the release zip
- [ ] Verify notarization completes when notary secrets are configured
- [ ] Verify notarization is skipped gracefully when notary secrets are absent
- [ ] Verify iOS Simulator build still works alongside the macOS build
- [ ] Verify keychain cleanup runs even on failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)