### PR TITLE
fix(ios): prevent first-launch watchdog crash from blocking host name lookup

### DIFF
--- a/RuntimeViewerCore/Sources/RuntimeViewerCommunication/Connections/RuntimeNetworkConnection.swift
+++ b/RuntimeViewerCore/Sources/RuntimeViewerCommunication/Connections/RuntimeNetworkConnection.swift
@@ -388,7 +388,7 @@ final class RuntimeNetworkServerConnection: RuntimeConnectionBase<RuntimeNetwork
         var lastError: Error = RuntimeConnectionError.listenerWaiting
         for attempt in 0..<Self.maxListenerRetries {
             let newListener = try NWListener(using: listenerParameters)
-            newListener.service = RuntimeNetworkBonjour.makeService(name: serviceName)
+            newListener.service = await RuntimeNetworkBonjour.makeService(name: serviceName)
             self.listener = newListener
 
             if attempt > 0 {
@@ -575,7 +575,7 @@ final class RuntimeNetworkServerConnection: RuntimeConnectionBase<RuntimeNetwork
         ownStateSubject.send(.connecting)
 
         let newListener = try NWListener(using: listenerParameters)
-        newListener.service = RuntimeNetworkBonjour.makeService(name: serviceName)
+        newListener.service = await RuntimeNetworkBonjour.makeService(name: serviceName)
         self.listener = newListener
 
         newListener.stateUpdateHandler = { [weak self] state in

--- a/RuntimeViewerCore/Sources/RuntimeViewerCommunication/RuntimeNetwork.swift
+++ b/RuntimeViewerCore/Sources/RuntimeViewerCommunication/RuntimeNetwork.swift
@@ -79,18 +79,22 @@ public enum RuntimeNetworkBonjour {
         return String(cString: buffer)
     }
 
-    /// The human-readable host name for this device, used in Bonjour TXT records.
+    /// Synchronous, non-blocking local host name.
     ///
-    /// On iOS 16+, `UIDevice.current.name` returns a generic model name (e.g. "iPhone")
-    /// without the `user-assigned-device-name` entitlement. We use the Bonjour hostname
-    /// (e.g. "JHs-iPhone") as a more identifiable fallback.
+    /// Safe to read from any thread — it never touches the network — but the
+    /// value can be a generic fallback like `"iPhone"` on iOS devices because
+    /// the only non-blocking sources (`gethostname(2)`, `UIDevice.current.name`
+    /// without the `user-assigned-device-name` entitlement) don't expose the
+    /// user's device name.
+    ///
+    /// Use this only where blocking is unacceptable (e.g. as the default
+    /// `RuntimeEngine.hostInfo`). For Bonjour TXT records and service names
+    /// that other devices will see, prefer ``resolvedHostName()``.
     public static let localHostName: String = {
         #if os(macOS)
         return (SCDynamicStoreCopyComputerName(nil, nil) as? String)
             ?? systemHostName()
         #else
-        // On real devices (iOS 16+), UIDevice.current.name returns generic "iPhone"
-        // without entitlement, so prefer the Bonjour hostname (e.g. "jhs-iphone-pro").
         #if !targetEnvironment(simulator)
         let hostName = systemHostName()
             .replacingOccurrences(of: ".local", with: "")
@@ -108,10 +112,39 @@ public enum RuntimeNetworkBonjour {
         #endif
     }()
 
-    static func makeService(name: String) -> NWListener.Service {
+    /// User-friendly local host name, resolved off the calling thread.
+    ///
+    /// On iOS devices `ProcessInfo.processInfo.hostName` reaches the
+    /// user-assigned name (e.g. `"JHs-iPhone"`) by performing a *blocking*
+    /// reverse-DNS lookup against mDNSResponder. We hop onto a detached
+    /// background task so the calling thread (often the main thread during
+    /// scene-create) is never blocked even when the mDNS cache is cold —
+    /// that scenario was the cause of the `0x8BADF00D` watchdog crash on
+    /// first launch.
+    ///
+    /// The mDNSResponder cache means the second call is essentially free.
+    public static func resolvedHostName() async -> String {
+        await Task.detached(priority: .utility) {
+            #if os(macOS)
+            if let name = SCDynamicStoreCopyComputerName(nil, nil) as? String,
+               !name.isEmpty {
+                return name
+            }
+            #elseif !targetEnvironment(simulator) && !os(watchOS)
+            let mdnsName = ProcessInfo.processInfo.hostName
+                .replacingOccurrences(of: ".local", with: "")
+            if !mdnsName.isEmpty && mdnsName != "localhost" {
+                return mdnsName
+            }
+            #endif
+            return localHostName
+        }.value
+    }
+
+    static func makeService(name: String) async -> NWListener.Service {
         var txtRecord = NWTXTRecord()
         txtRecord[instanceIDKey] = localInstanceID
-        txtRecord[hostNameKey] = localHostName
+        txtRecord[hostNameKey] = await resolvedHostName()
         txtRecord[modelIDKey] = DeviceMetadata.current.modelIdentifier
         txtRecord[osVersionKey] = DeviceMetadata.current.osVersion
         if DeviceMetadata.current.isSimulator {

--- a/RuntimeViewerCore/Sources/RuntimeViewerCommunication/RuntimeNetwork.swift
+++ b/RuntimeViewerCore/Sources/RuntimeViewerCommunication/RuntimeNetwork.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Darwin
 public import FoundationToolbox
 import Network
 #if canImport(UIKit)
@@ -62,6 +63,22 @@ public enum RuntimeNetworkBonjour {
         return newID
     }()
 
+    /// Reads the kernel hostname via POSIX `gethostname(2)`.
+    ///
+    /// `ProcessInfo.processInfo.hostName` and `Host.current().name` go through
+    /// `-[NSHost name]`, which performs a *blocking* reverse-DNS lookup. On a
+    /// fresh iOS install with a cold mDNS cache that lookup can stall the
+    /// caller for tens of seconds — long enough to trip FrontBoard's
+    /// scene-create watchdog (`0x8BADF00D`). `gethostname(2)` reads the value
+    /// directly from the kernel and never touches the network.
+    private static func systemHostName() -> String {
+        var buffer = [CChar](repeating: 0, count: 256)
+        guard gethostname(&buffer, buffer.count) == 0 else {
+            return ""
+        }
+        return String(cString: buffer)
+    }
+
     /// The human-readable host name for this device, used in Bonjour TXT records.
     ///
     /// On iOS 16+, `UIDevice.current.name` returns a generic model name (e.g. "iPhone")
@@ -70,12 +87,12 @@ public enum RuntimeNetworkBonjour {
     public static let localHostName: String = {
         #if os(macOS)
         return (SCDynamicStoreCopyComputerName(nil, nil) as? String)
-            ?? ProcessInfo.processInfo.hostName
+            ?? systemHostName()
         #else
         // On real devices (iOS 16+), UIDevice.current.name returns generic "iPhone"
         // without entitlement, so prefer the Bonjour hostname (e.g. "jhs-iphone-pro").
         #if !targetEnvironment(simulator)
-        let hostName = ProcessInfo.processInfo.hostName
+        let hostName = systemHostName()
             .replacingOccurrences(of: ".local", with: "")
         if !hostName.isEmpty && hostName != "localhost" {
             return hostName
@@ -86,7 +103,7 @@ public enum RuntimeNetworkBonjour {
         #elseif canImport(UIKit)
         return UIDevice.current.name
         #else
-        return ProcessInfo.processInfo.hostName
+        return systemHostName()
         #endif
         #endif
     }()

--- a/RuntimeViewerUsingUIKit/RuntimeViewerUsingUIKit.xcodeproj/project.pbxproj
+++ b/RuntimeViewerUsingUIKit/RuntimeViewerUsingUIKit.xcodeproj/project.pbxproj
@@ -465,6 +465,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "$(TARGET_NAME)/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = RuntimeViewer;
+				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -494,6 +495,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "$(TARGET_NAME)/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = RuntimeViewer;
+				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -656,8 +658,9 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = RuntimeViewerUsingUIKit/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = RuntimeViewer;
+				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
-				INFOPLIST_KEY_NSLocalNetworkUsageDescription = "RuntimeViewer requires local network permissions to use the Bonjour discovery service";
+				INFOPLIST_KEY_NSLocalNetworkUsageDescription = "RuntimeViewer uses the local network to discover and connect to runtime inspection services on nearby devices.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
@@ -697,8 +700,9 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = RuntimeViewerUsingUIKit/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = RuntimeViewer;
+				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
-				INFOPLIST_KEY_NSLocalNetworkUsageDescription = "RuntimeViewer requires local network permissions to use the Bonjour discovery service";
+				INFOPLIST_KEY_NSLocalNetworkUsageDescription = "RuntimeViewer uses the local network to discover and connect to runtime inspection services on nearby devices.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";

--- a/RuntimeViewerUsingUIKit/RuntimeViewerUsingUIKit.xcodeproj/project.pbxproj
+++ b/RuntimeViewerUsingUIKit/RuntimeViewerUsingUIKit.xcodeproj/project.pbxproj
@@ -470,7 +470,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 2.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.JH.RuntimeViewer;
 				PRODUCT_NAME = RuntimeViewer;
 				SDKROOT = xros;
@@ -499,7 +499,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 2.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.JH.RuntimeViewer;
 				PRODUCT_NAME = RuntimeViewer;
 				SDKROOT = xros;
@@ -667,7 +667,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 2.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.JH.RuntimeViewer;
 				PRODUCT_NAME = RuntimeViewer;
 				SDKROOT = iphoneos;
@@ -708,7 +708,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 2.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.JH.RuntimeViewer;
 				PRODUCT_NAME = RuntimeViewer;
 				SDKROOT = iphoneos;

--- a/RuntimeViewerUsingUIKit/RuntimeViewerUsingUIKit/App/AppDelegate.swift
+++ b/RuntimeViewerUsingUIKit/RuntimeViewerUsingUIKit/App/AppDelegate.swift
@@ -17,7 +17,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             #log(.info,"Local runtime engine initialized")
         }
         Task {
-            let deviceName = RuntimeNetworkBonjour.localHostName
+            // Resolve the user-friendly host name off the main thread —
+            // mDNS reverse-DNS can stall for tens of seconds on a cold cache
+            // (the first launch after install). Blocking the main thread
+            // there would trip the scene-create watchdog (0x8BADF00D).
+            let deviceName = await RuntimeNetworkBonjour.resolvedHostName()
             let deviceID = DeviceIdentifier.uniqueDeviceID
             #log(.info,"Creating Bonjour server runtime engine with name: \(deviceName, privacy: .public), identifier: \(deviceID, privacy: .private)")
             remoteRuntimeEngine = RuntimeEngine(source: .bonjour(name: deviceName, identifier: .init(rawValue: deviceID), role: .server))

--- a/RuntimeViewerUsingUIKit/RuntimeViewerUsingUIKit/Info.plist
+++ b/RuntimeViewerUsingUIKit/RuntimeViewerUsingUIKit/Info.plist
@@ -6,8 +6,6 @@
 	<array>
 		<string>_runtimeviewer._tcp</string>
 	</array>
-	<key>NSLocalNetworkUsageDescription</key>
-	<string>RuntimeViewer uses the local network to discover and connect to runtime inspection services on nearby devices.</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>


### PR DESCRIPTION
## Summary

- Fixes a `0x8BADF00D` watchdog termination on first launch of the iOS app, caused by `ProcessInfo.processInfo.hostName` issuing a blocking mDNS reverse-DNS lookup on the main thread while the cache is cold.
- Splits the host name API in two: `localHostName` is now a guaranteed-non-blocking value (via `gethostname(2)`), suitable for synchronous defaults; `resolvedHostName()` is async and runs the blocking lookup on a detached utility task to recover the user-assigned name (e.g. `JHs-iPhone`) for Bonjour TXT records.
- Adds `ITSAppUsesNonExemptEncryption = NO` to all UIKit target build settings and consolidates `NSLocalNetworkUsageDescription` into the pbxproj.

## Test plan

- [ ] Delete the app from a real iOS device, reinstall, and launch — verify no watchdog crash and that Bonjour advertises the user-assigned device name.
- [ ] Launch with the device in Airplane Mode — verify the app still starts and falls back gracefully.
- [ ] Verify macOS server still advertises the computer name from `SCDynamicStoreCopyComputerName`.
- [ ] Verify simulator builds advertise a sensible host name.