### PR TITLE
Add ObjC ivar offset transformer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,19 @@ Runtime Viewer is a macOS/iOS application for inspecting Objective-C and Swift r
 
 ## Build Commands
 
+### Catalyst Helper Build Order
+
+For native macOS builds, build `RuntimeViewerCatalystHelper` first, then build
+`RuntimeViewer macOS` / `RuntimeViewerUsingAppKit` in the same Xcode/DerivedData
+session. Do not model this as a direct target dependency: Xcode treats the Mac
+Catalyst helper as iOS-family embedded content and rejects it from the macOS app
+target. `ReleaseScript.sh` already handles this by archiving/exporting the
+helper before the main app.
+
+Recommended Xcode order:
+1. Build `RuntimeViewerCatalystHelper` for `My Mac (Mac Catalyst)`.
+2. Build `RuntimeViewer macOS` for `My Mac`.
+
 ```bash
 # Debug build (x86_64 and arm64e)
 ./BuildScript.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,18 @@ Runtime Viewer is a macOS/iOS document-based (NSDocument) application for inspec
 
 **Workspace preference**: Before running any `xcodebuild` / `swift build` / `swift test`, check whether `../MxIris-Reverse-Engineering.xcworkspace` (sibling of this repo) exists. If it does, **use that workspace** via `xcodebuild -workspace ../MxIris-Reverse-Engineering.xcworkspace -scheme <scheme> ...` — it wires this repo together with local checkouts of MachOKit / MachOObjCSection / MachOSwiftSection / swift-capstone / swift-demangling / swift-semantic-string / swift-syntax that may contain in-progress fixes not yet published upstream. Building against the remote SPM resolution can hit stale errors (e.g. the MachOSwiftSection `@Mutex` macro expansion bug) that the workspace's local checkout already fixes. Only fall back to the standalone commands below when the workspace is absent.
 
+**Catalyst helper build order**: For native macOS builds, build
+`RuntimeViewerCatalystHelper` first, then build `RuntimeViewer macOS` /
+`RuntimeViewerUsingAppKit` in the same Xcode/DerivedData session. Do not model
+this as a direct target dependency: Xcode treats the Mac Catalyst helper as
+iOS-family embedded content and rejects it from the macOS app target.
+`ReleaseScript.sh` already handles this by archiving/exporting the helper before
+the main app.
+
+Recommended Xcode order:
+1. Build `RuntimeViewerCatalystHelper` for `My Mac (Mac Catalyst)`.
+2. Build `RuntimeViewer macOS` for `My Mac`.
+
 ```bash
 # Debug build (x86_64 and arm64e)
 ./BuildScript.sh

--- a/RuntimeViewerCore/Sources/RuntimeViewerCore/Core/RuntimeObjCSection.swift
+++ b/RuntimeViewerCore/Sources/RuntimeViewerCore/Core/RuntimeObjCSection.swift
@@ -339,6 +339,7 @@ actor RuntimeObjCSection {
         #log(.debug, "Generating interface for: \(object.name, privacy: .public)")
         let name = object.withImagePath(imagePath)
         let cTypeReplacements = transformer.cType.isEnabled ? transformer.cType.replacements : [:]
+        let ivarOffsetTransformer = transformer.ivarOffset.isEnabled ? transformer.ivarOffset : nil
         let objcDumpContext = ObjCDumpContext(machO: machO, options: options, cTypeReplacements: cTypeReplacements) { name, isStruct in
             guard let name else { return true }
             if isStruct {
@@ -347,6 +348,7 @@ actor RuntimeObjCSection {
                 return self.unions[name] == nil
             }
         }
+        objcDumpContext.ivarOffsetTransformer = ivarOffsetTransformer
 
         switch name.kind {
         case .objc(.type(.class)):

--- a/RuntimeViewerCore/Sources/RuntimeViewerCore/Transformer/Transformer+ObjCIvarOffset.swift
+++ b/RuntimeViewerCore/Sources/RuntimeViewerCore/Transformer/Transformer+ObjCIvarOffset.swift
@@ -1,0 +1,87 @@
+import Foundation
+import MetaCodable
+
+// MARK: - ObjC Ivar Offset Transformer Module
+
+extension Transformer {
+    /// Customizes ObjC ivar offset comment format using token templates.
+    @Codable
+    public struct ObjCIvarOffset: Module {
+        public typealias Parameter = Token
+        public typealias Output = String
+
+        public static let displayName = "ObjC Ivar Offset Comment"
+
+        @Default(ifMissing: false)
+        public var isEnabled: Bool
+
+        @Default(ifMissing: Templates.standard)
+        public var template: String
+
+        @Default(ifMissing: true)
+        public var useHexadecimal: Bool
+
+        public init(isEnabled: Bool = false, template: String = Templates.standard, useHexadecimal: Bool = true) {
+            self.isEnabled = isEnabled
+            self.template = template
+            self.useHexadecimal = useHexadecimal
+        }
+
+        public func transform(_ input: Input) -> String {
+            template
+                .replacingOccurrences(of: Token.offset.placeholder, with: formatValue(input.offset))
+        }
+
+        private func formatValue(_ value: Int) -> String {
+            useHexadecimal ? "0x\(String(value, radix: 16, uppercase: true))" : String(value)
+        }
+
+        public func contains(_ token: Token) -> Bool {
+            template.contains(token.placeholder)
+        }
+    }
+}
+
+// MARK: - Input
+
+extension Transformer.ObjCIvarOffset {
+    public struct Input: Sendable {
+        public let offset: Int
+
+        public init(offset: Int) {
+            self.offset = offset
+        }
+    }
+}
+
+// MARK: - Token
+
+extension Transformer.ObjCIvarOffset {
+    public enum Token: String, CaseIterable, Sendable {
+        case offset
+
+        public var placeholder: String { "${\(rawValue)}" }
+
+        public var displayName: String {
+            switch self {
+            case .offset: "Offset"
+            }
+        }
+    }
+}
+
+// MARK: - Templates
+
+extension Transformer.ObjCIvarOffset {
+    public enum Templates {
+        public static let standard = "offset: ${offset}"
+        public static let labeled = "ivar offset: ${offset}"
+        public static let bare = "${offset}"
+
+        public static let all: [(name: String, template: String)] = [
+            ("Standard", standard),
+            ("Labeled", labeled),
+            ("Bare", bare),
+        ]
+    }
+}

--- a/RuntimeViewerCore/Sources/RuntimeViewerCore/Transformer/Transformer.swift
+++ b/RuntimeViewerCore/Sources/RuntimeViewerCore/Transformer/Transformer.swift
@@ -49,9 +49,12 @@ extension Transformer {
     public struct ObjCConfiguration: Sendable, Equatable, Hashable {
         @Default(ifMissing: Transformer.CType())
         public var cType: Transformer.CType
+        @Default(ifMissing: Transformer.ObjCIvarOffset())
+        public var ivarOffset: Transformer.ObjCIvarOffset
 
-        public init(cType: CType = .init()) {
+        public init(cType: CType = .init(), ivarOffset: ObjCIvarOffset = .init()) {
             self.cType = cType
+            self.ivarOffset = ivarOffset
         }
     }
 }
@@ -105,7 +108,7 @@ extension Transformer {
         
         /// Whether any module is enabled.
         public var hasEnabledModules: Bool {
-            objc.cType.isEnabled || swift.swiftFieldOffset.isEnabled || swift.swiftVTableOffset.isEnabled || swift.swiftMemberAddress.isEnabled || swift.swiftTypeLayout.isEnabled || swift.swiftEnumLayout.isEnabled
+            objc.cType.isEnabled || objc.ivarOffset.isEnabled || swift.swiftFieldOffset.isEnabled || swift.swiftVTableOffset.isEnabled || swift.swiftMemberAddress.isEnabled || swift.swiftTypeLayout.isEnabled || swift.swiftEnumLayout.isEnabled
         }
     }
 }

--- a/RuntimeViewerCore/Sources/RuntimeViewerCore/Utils/ObjCDump+SemanticString.swift
+++ b/RuntimeViewerCore/Sources/RuntimeViewerCore/Utils/ObjCDump+SemanticString.swift
@@ -11,6 +11,7 @@ final class ObjCDumpContext {
     let machO: MachOImage
     var options: ObjCGenerationOptions
     var cTypeReplacements: [Transformer.CType.Pattern: String] = [:]
+    var ivarOffsetTransformer: Transformer.ObjCIvarOffset?
     var currentArray: SemanticString?
     var methodIMPs: [String: UInt64] = [:]
     var classMethodIMPs: [String: UInt64] = [:]
@@ -232,7 +233,11 @@ extension ObjCIvarInfo {
 
         if context.options.addIvarOffsetComments {
             Space()
-            Comment("offset: \(offset)")
+            if let ivarOffsetTransformer = context.ivarOffsetTransformer {
+                Comment(ivarOffsetTransformer.transform(.init(offset: offset)))
+            } else {
+                Comment("offset: \(offset)")
+            }
         }
     }
 }

--- a/RuntimeViewerCore/Tests/RuntimeViewerCoreTests/TransformerTests.swift
+++ b/RuntimeViewerCore/Tests/RuntimeViewerCoreTests/TransformerTests.swift
@@ -11,6 +11,7 @@ struct TransformerConfigurationTests {
         let config = Transformer.Configuration.default
         #expect(config.hasEnabledModules == false)
         #expect(config.objc.cType.isEnabled == false)
+        #expect(config.objc.ivarOffset.isEnabled == false)
         #expect(config.swift.swiftFieldOffset.isEnabled == false)
         #expect(config.swift.swiftTypeLayout.isEnabled == false)
         #expect(config.swift.swiftEnumLayout.isEnabled == false)
@@ -20,6 +21,13 @@ struct TransformerConfigurationTests {
     func hasEnabledModulesCType() {
         var config = Transformer.Configuration.default
         config.objc.cType.isEnabled = true
+        #expect(config.hasEnabledModules == true)
+    }
+
+    @Test("hasEnabledModules returns true when ObjCIvarOffset is enabled")
+    func hasEnabledModulesObjCIvarOffset() {
+        var config = Transformer.Configuration.default
+        config.objc.ivarOffset.isEnabled = true
         #expect(config.hasEnabledModules == true)
     }
 
@@ -49,6 +57,8 @@ struct TransformerConfigurationTests {
         var config = Transformer.Configuration.default
         config.objc.cType.isEnabled = true
         config.objc.cType.replacements = [.double: "CGFloat"]
+        config.objc.ivarOffset.isEnabled = true
+        config.objc.ivarOffset.template = "ivar: ${offset}"
         config.swift.swiftFieldOffset.isEnabled = true
         config.swift.swiftFieldOffset.template = "offset: ${startOffset}"
 
@@ -159,6 +169,70 @@ struct TransformerCTypeTests {
         let original = Transformer.CType(isEnabled: true, replacements: [.int: "int32_t", .double: "CGFloat"])
         let data = try JSONEncoder().encode(original)
         let decoded = try JSONDecoder().decode(Transformer.CType.self, from: data)
+        #expect(decoded == original)
+    }
+}
+
+// MARK: - ObjCIvarOffset Tests
+
+@Suite("Transformer.ObjCIvarOffset")
+struct TransformerObjCIvarOffsetTests {
+    @Test("displayName")
+    func displayName() {
+        #expect(Transformer.ObjCIvarOffset.displayName == "ObjC Ivar Offset Comment")
+    }
+
+    @Test("default init")
+    func defaultInit() {
+        let module = Transformer.ObjCIvarOffset()
+        #expect(module.isEnabled == false)
+        #expect(module.template == Transformer.ObjCIvarOffset.Templates.standard)
+        #expect(module.useHexadecimal == true)
+    }
+
+    @Test("transform with standard template and hex")
+    func transformStandardHex() {
+        let module = Transformer.ObjCIvarOffset(isEnabled: true, template: Transformer.ObjCIvarOffset.Templates.standard, useHexadecimal: true)
+        let result = module.transform(.init(offset: 32))
+        #expect(result == "offset: 0x20")
+    }
+
+    @Test("transform with standard template and decimal")
+    func transformStandardDecimal() {
+        let module = Transformer.ObjCIvarOffset(isEnabled: true, template: Transformer.ObjCIvarOffset.Templates.standard, useHexadecimal: false)
+        let result = module.transform(.init(offset: 32))
+        #expect(result == "offset: 32")
+    }
+
+    @Test("contains checks token presence in template")
+    func containsToken() {
+        let module = Transformer.ObjCIvarOffset(template: Transformer.ObjCIvarOffset.Templates.standard)
+        #expect(module.contains(.offset) == true)
+
+        let staticModule = Transformer.ObjCIvarOffset(template: "offset")
+        #expect(staticModule.contains(.offset) == false)
+    }
+
+    @Test("Token placeholder")
+    func tokenPlaceholder() {
+        #expect(Transformer.ObjCIvarOffset.Token.offset.placeholder == "${offset}")
+    }
+
+    @Test("Token displayName")
+    func tokenDisplayName() {
+        #expect(Transformer.ObjCIvarOffset.Token.offset.displayName == "Offset")
+    }
+
+    @Test("Templates.all has 3 entries")
+    func templatesAll() {
+        #expect(Transformer.ObjCIvarOffset.Templates.all.count == 3)
+    }
+
+    @Test("Codable round-trip")
+    func codable() throws {
+        let original = Transformer.ObjCIvarOffset(isEnabled: true, template: "custom: ${offset}", useHexadecimal: false)
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(Transformer.ObjCIvarOffset.self, from: data)
         #expect(decoded == original)
     }
 }

--- a/RuntimeViewerPackages/Sources/RuntimeViewerSettingsUI/Components/TransformerSettingsView.swift
+++ b/RuntimeViewerPackages/Sources/RuntimeViewerSettingsUI/Components/TransformerSettingsView.swift
@@ -32,6 +32,22 @@ struct TransformerSettingsView: View {
                 }
             }
 
+            // MARK: - ObjC Ivar Offset Module
+
+            Section {
+                Toggle("Transform ObjC Ivar Offset Comment", isOn: $config.objc.ivarOffset.isEnabled)
+            } footer: {
+                Text("Transform ObjC ivar offset comment format in ObjC interfaces.")
+            }
+
+            if config.objc.ivarOffset.isEnabled {
+                Section {
+                    ObjCIvarOffsetEditor(module: $config.objc.ivarOffset)
+                } header: {
+                    Text("Output Format")
+                }
+            }
+
             // MARK: - Swift Field Offset Module
 
             Section {
@@ -192,6 +208,65 @@ private struct CTypePresets: View {
             }
             .buttonStyle(.bordered)
             .controlSize(.small)
+        }
+    }
+}
+
+// MARK: - ObjC Ivar Offset Editor
+
+private struct ObjCIvarOffsetEditor: View {
+    @Binding var module: Transformer.ObjCIvarOffset
+    @State private var textFieldHeight: CGFloat = 24
+
+    var body: some View {
+        Grid(alignment: .leading, horizontalSpacing: 8, verticalSpacing: 10) {
+            GridRow {
+                Text("Template")
+                    .foregroundStyle(.secondary)
+                    .gridColumnAlignment(.trailing)
+
+                TokenTemplateTextField(text: $module.template, height: $textFieldHeight)
+                    .frame(height: max(24, textFieldHeight))
+            }
+
+            GridRow {
+                Text("Radix")
+                    .foregroundStyle(.secondary)
+
+                Picker("", selection: $module.useHexadecimal) {
+                    Text("Decimal").tag(false)
+                    Text("Hexadecimal").tag(true)
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+                .fixedSize()
+            }
+
+            GridRow {
+                Text("Tokens")
+                    .foregroundStyle(.secondary)
+
+                HStack(spacing: 8) {
+                    ForEach(Transformer.ObjCIvarOffset.Token.allCases, id: \.self) { token in
+                        CopyableTokenChip(token: token, placeholder: token.placeholder)
+                    }
+                }
+            }
+
+            GridRow {
+                Text("Presets")
+                    .foregroundStyle(.secondary)
+
+                FlowLayout(spacing: 6) {
+                    ForEach(Transformer.ObjCIvarOffset.Templates.all, id: \.name) { preset in
+                        Button(preset.name) {
+                            module.template = preset.template
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- add a configurable ObjC ivar offset transformer
- expose the transformer in settings
- document that RuntimeViewerCatalystHelper must be built before the macOS app