### PR TITLE
chore: update appcast for v2.0.1

### DIFF
--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -11,6 +11,14 @@
         <description>RuntimeViewer release feed</description>
         <language>en</language>
         <item>
+            <title>2.0.1</title>
+            <pubDate>Fri, 01 May 2026 14:50:02 +0000</pubDate>
+            <sparkle:version>20260501.14.05</sparkle:version>
+            <sparkle:shortVersionString>2.0.1</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>15.0</sparkle:minimumSystemVersion>
+            <enclosure url="https://github.com/MxIris-Reverse-Engineering/RuntimeViewer/releases/download/v2.0.1/RuntimeViewer-macOS.zip" length="49117407" type="application/octet-stream" sparkle:edSignature="aDH4vL7aK92C4CRNIRN/ptpbTGrgc0WzxzrpD6Von+qiJrCqBNGZWFKgRDPQdfFUqPhfBqsLaSolXq8Q1DKgBA=="/>
+        </item>
+        <item>
             <title>2.0.0</title>
             <pubDate>Fri, 24 Apr 2026 15:36:09 +0800</pubDate>
             <sparkle:version>20260424.06.08</sparkle:version>


### PR DESCRIPTION
## Summary

- Manually append the v2.0.1 entry to `docs/appcast.xml`. CI generated it during the `v2.0.1` release run but its direct push to `main` was declined by the new branch-protection rule (see [run 25217276576](https://github.com/MxIris-Reverse-Engineering/RuntimeViewer/actions/runs/25217276576), step *Run ArchiveScript*).
- The `v2.0.1` GitHub Release and zip assets are already live; only the appcast was missing, so Sparkle clients on v2.0.0 were not yet seeing the update.
- Signature obtained locally via `sign_update` on the released `RuntimeViewer-macOS.zip`; `sparkle:version` (20260501.14.05), `length` (49117407), and `sparkle:shortVersionString` match `Info.plist` inside the published archive.

## Follow-up (separate PR)

ArchiveScript needs to either open a PR for the appcast bump or push via a token that bypasses the branch-protection rule, otherwise the next release will hit the same wall.

## Test plan

- [ ] Merge this PR.
- [ ] Confirm `https://mxiris-reverse-engineering.github.io/RuntimeViewer/appcast.xml` serves the v2.0.1 entry within a few minutes (GitHub Pages refresh).
- [ ] Trigger **Check for Updates…** on a v2.0.0 build and verify it offers v2.0.1.