### PR TITLE
ci(release): merge appcast update via PR instead of pushing main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,7 @@ jobs:
     runs-on: ${{ inputs.runner || 'macos-26' }}
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout

--- a/ArchiveScript.sh
+++ b/ArchiveScript.sh
@@ -349,14 +349,15 @@ if $COMMIT_PUSH; then
         run git push origin HEAD
     else
         # Detached HEAD (tag-triggered CI). Apply the freshly generated
-        # appcast.xml as a standalone commit on top of origin/main, so we
-        # don't try to push a nameless HEAD and don't sweep unrelated
-        # feature-branch commits along for the ride.
-        log "Detached HEAD; applying appcast update on top of origin/main"
+        # appcast.xml as a standalone commit on top of origin/main, then
+        # push it to a dedicated branch and merge it via a pull request,
+        # because the main branch ruleset rejects direct pushes.
+        log "Detached HEAD; opening PR for appcast update"
         tmp_appcast=$(mktemp)
         cp docs/appcast.xml "$tmp_appcast"
         run git fetch origin main
-        run git checkout -B "appcast-for-$VERSION_TAG" origin/main
+        APPCAST_BRANCH="appcast-for-$VERSION_TAG"
+        run git checkout -B "$APPCAST_BRANCH" origin/main
         cp "$tmp_appcast" docs/appcast.xml
         rm -f "$tmp_appcast"
         if git diff --quiet docs/appcast.xml; then
@@ -364,7 +365,11 @@ if $COMMIT_PUSH; then
         else
             run git add docs/appcast.xml
             run git commit -m "chore: update appcast for $VERSION_TAG"
-            run git push origin "HEAD:refs/heads/main"
+            run git push origin "HEAD:refs/heads/$APPCAST_BRANCH"
+            run gh pr create --base main --head "$APPCAST_BRANCH" \
+                --title "chore: update appcast for $VERSION_TAG" \
+                --body "Automated appcast update from the release CI run for $VERSION_TAG."
+            run gh pr merge "$APPCAST_BRANCH" --squash --delete-branch
         fi
     fi
 fi


### PR DESCRIPTION
## Summary

- Long-term fix for the release-CI failure on v2.0.1: the "Main Protect" ruleset rejects direct pushes to `main`, which is exactly what `ArchiveScript.sh` did at the end of every tag-triggered run. Build/notarize/GitHub Release all succeeded for v2.0.1, but the final `git push origin HEAD:refs/heads/main` for the appcast bump was declined.
- Switch the detached-HEAD branch in `ArchiveScript.sh` to push the appcast commit onto `appcast-for-<tag>`, open a PR against main via `gh pr create`, and squash-merge it via `gh pr merge --squash --delete-branch`.
- Grant the workflow `pull-requests: write` so the default `GITHUB_TOKEN` can both open and merge the PR.

The ruleset's `pull_request` rule already allows squash-merging with no reviews or required checks, so the PR flow merges immediately.

## Test plan

- [ ] On the next real tag-triggered release, watch the `Run ArchiveScript` step succeed end-to-end and a `chore: update appcast for vX.Y.Z` PR appear and auto-merge into main.
- [ ] Confirm `https://mxiris-reverse-engineering.github.io/RuntimeViewer/appcast.xml` picks up the new entry within a few minutes of the merge.