### PR TITLE
refactor: ViewInvalidating sizing, NSAttributedStringBuilder trait, sidebar expansion

### DIFF
--- a/RuntimeViewer-Debug.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/RuntimeViewer-Debug.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -55,24 +55,6 @@
       }
     },
     {
-      "identity" : "dsfappearancemanager",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/dagronf/DSFAppearanceManager",
-      "state" : {
-        "revision" : "e9add5fdf05fe50950d105c77963b7373ddb5ad4",
-        "version" : "3.5.1"
-      }
-    },
-    {
-      "identity" : "dsfquickactionbar",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/MxIris-macOS-Library-Forks/DSFQuickActionBar",
-      "state" : {
-        "revision" : "ae07ffcd50bedd418b46d096f4785f7c3bc96e3e",
-        "version" : "6.2.102"
-      }
-    },
-    {
       "identity" : "enumkit",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gringoireDM/EnumKit.git",
@@ -82,21 +64,12 @@
       }
     },
     {
-      "identity" : "filter-ui",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/MxIris-macOS-Library-Forks/filter-ui",
-      "state" : {
-        "revision" : "0d7d6d0fe5e478d7a70f6b1b014998b96e2b171e",
-        "version" : "0.1.2"
-      }
-    },
-    {
       "identity" : "frameworktoolbox",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Mx-Iris/FrameworkToolbox",
       "state" : {
-        "revision" : "22f92afb2520417e60a464a6a5abb88621c2b43d",
-        "version" : "0.5.3"
+        "revision" : "4ab712e98990bb3a44a5ef160bd0b0c3f03ace08",
+        "version" : "0.5.5"
       }
     },
     {
@@ -106,15 +79,6 @@
       "state" : {
         "revision" : "1a88d6807a174ebb90e2a04e2071944e006847ef",
         "version" : "0.1.0"
-      }
-    },
-    {
-      "identity" : "ide-icons",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/MxIris-Library-Forks/ide-icons",
-      "state" : {
-        "revision" : "d262688aecaf1cdab961b2a504566ae5f71c29d1",
-        "version" : "0.1.3"
       }
     },
     {
@@ -646,15 +610,6 @@
       "state" : {
         "revision" : "42d259b5d2b3d5cb4ce14281ce86f010034ff36c",
         "version" : "0.1.0"
-      }
-    },
-    {
-      "identity" : "uifoundation",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/Mx-Iris/UIFoundation",
-      "state" : {
-        "revision" : "d7c490fd668e26ccf82e1776ce77c32e4ca8f3e3",
-        "version" : "0.5.1"
       }
     },
     {

--- a/RuntimeViewerPackages/Package.swift
+++ b/RuntimeViewerPackages/Package.swift
@@ -163,7 +163,7 @@ let package = Package(
             .package(
                 path: "../../UIFoundation",
                 isRelative: true,
-                isEnabled: usingLocalDependencies,
+                isEnabled: true,
                 traits: UIFoundationTraits,
             ),
             remote: .package(

--- a/RuntimeViewerPackages/Package.swift
+++ b/RuntimeViewerPackages/Package.swift
@@ -95,7 +95,7 @@ let usingLocalDependencies = envEnable("USING_LOCAL_DEPENDENCIES")
 
 var sharedSwiftSettings: [SwiftSetting] = []
 
-let UIFoundationTraits: Set<PackageDescription.Package.Dependency.Trait> = ["AppleInternal", "FilterUI", "IDEIcons", "QuickActionBar"]
+let UIFoundationTraits: Set<PackageDescription.Package.Dependency.Trait> = ["AppleInternal", "FilterUI", "IDEIcons", "QuickActionBar", "NSAttributedStringBuilder"]
 
 if usingSystemUXKit {
     sharedSwiftSettings.append(.define("USING_SYSTEM_UXKIT"))
@@ -243,10 +243,6 @@ let package = Package(
                 url: "https://github.com/OpenUXKit/OpenUXKit",
                 branch: "main"
             )
-        ),
-        .package(
-            url: "https://github.com/MxIris-Library-Forks/NSAttributedStringBuilder",
-            from: "0.4.2"
         ),
         .package(
             url: "https://github.com/Mx-Iris/SFSymbols",
@@ -408,7 +404,6 @@ let package = Package(
                 .product(name: "UIFoundationToolbox", package: "UIFoundation"),
                 .product(name: "SnapKit", package: "SnapKit"),
                 .product(name: usingSystemUXKit ? "UXKit" : "OpenUXKit", package: "OpenUXKit", condition: .when(platforms: appkitPlatforms)),
-                .product(name: "NSAttributedStringBuilder", package: "NSAttributedStringBuilder"),
                 .product(name: "SFSymbols", package: "SFSymbols"),
                 .product(name: "Rearrange", package: "Rearrange", condition: .when(platforms: appkitPlatforms)),
                 .product(name: "RunningApplicationKit", package: "RunningApplicationKit", condition: .when(platforms: appkitPlatforms)),

--- a/RuntimeViewerPackages/Sources/RuntimeViewerApplication/Sidebar/SidebarRootViewModel.swift
+++ b/RuntimeViewerPackages/Sources/RuntimeViewerApplication/Sidebar/SidebarRootViewModel.swift
@@ -91,7 +91,7 @@ public class SidebarRootViewModel: ViewModel<SidebarRootRoute> {
         public let didBeginFiltering: Signal<Void>
         public let didChangeFiltering: Signal<Void>
         public let didEndFiltering: Signal<Void>
-        public let expandItem: Signal<SidebarRootCellViewModel>
+        public let toggleExpansion: Signal<(item: SidebarRootCellViewModel, maxDepth: Int)>
     }
 
     public func transform(_ input: Input) -> Output {
@@ -148,7 +148,13 @@ public class SidebarRootViewModel: ViewModel<SidebarRootRoute> {
             didBeginFiltering: $isFiltering.asSignal(onErrorJustReturn: false).filter { $0 }.mapToVoid(),
             didChangeFiltering: $filteredNodes.asSignal(onErrorJustReturn: []).withLatestFrom($isFiltering.asSignal(onErrorJustReturn: false)).filter { $0 }.mapToVoid(),
             didEndFiltering: $isFiltering.skip(1).asSignal(onErrorJustReturn: false).filter { !$0 }.mapToVoid(),
-            expandItem: input.clickedNode.filter { !$0.isLeaf }.asSignal(),
+            toggleExpansion: input.clickedNode
+                .filter { !$0.isLeaf }
+                .compactMap { [weak self] item -> (item: SidebarRootCellViewModel, maxDepth: Int)? in
+                    guard let self else { return nil }
+                    return (item, settings.general.sidebarMaxExpansionDepth)
+                }
+                .asSignal(onErrorSignalWith: .empty()),
         )
     }
 }

--- a/RuntimeViewerPackages/Sources/RuntimeViewerApplication/Sidebar/SidebarRootViewModel.swift
+++ b/RuntimeViewerPackages/Sources/RuntimeViewerApplication/Sidebar/SidebarRootViewModel.swift
@@ -91,6 +91,7 @@ public class SidebarRootViewModel: ViewModel<SidebarRootRoute> {
         public let didBeginFiltering: Signal<Void>
         public let didChangeFiltering: Signal<Void>
         public let didEndFiltering: Signal<Void>
+        public let expandItem: Signal<SidebarRootCellViewModel>
     }
 
     public func transform(_ input: Input) -> Output {
@@ -146,7 +147,8 @@ public class SidebarRootViewModel: ViewModel<SidebarRootRoute> {
             nodesIndexed: nodesIndexed,
             didBeginFiltering: $isFiltering.asSignal(onErrorJustReturn: false).filter { $0 }.mapToVoid(),
             didChangeFiltering: $filteredNodes.asSignal(onErrorJustReturn: []).withLatestFrom($isFiltering.asSignal(onErrorJustReturn: false)).filter { $0 }.mapToVoid(),
-            didEndFiltering: $isFiltering.skip(1).asSignal(onErrorJustReturn: false).filter { !$0 }.mapToVoid()
+            didEndFiltering: $isFiltering.skip(1).asSignal(onErrorJustReturn: false).filter { !$0 }.mapToVoid(),
+            expandItem: input.clickedNode.filter { !$0.isLeaf }.asSignal(),
         )
     }
 }

--- a/RuntimeViewerPackages/Sources/RuntimeViewerSettings/Settings+Types.swift
+++ b/RuntimeViewerPackages/Sources/RuntimeViewerSettings/Settings+Types.swift
@@ -18,7 +18,14 @@ extension Settings {
     public struct General {
         @Default(Settings.Appearances.system)
         public var appearance: Settings.Appearances
-        
+
+        /// Caps the recursion of `expandItem(_:expandChildren: true)` on
+        /// double-click. Without a cap, double-clicking a root with a deep
+        /// subtree (e.g. the dyld shared cache) freezes the main thread while
+        /// AppKit walks every descendant.
+        @Default(3)
+        public var sidebarMaxExpansionDepth: Int
+
         public static let `default` = Self()
     }
 

--- a/RuntimeViewerPackages/Sources/RuntimeViewerSettingsUI/Components/GeneralSettingsView.swift
+++ b/RuntimeViewerPackages/Sources/RuntimeViewerSettingsUI/Components/GeneralSettingsView.swift
@@ -17,7 +17,33 @@ struct GeneralSettingsView: View {
                     Text("Appearance")
                 }
             }
+
+            Section {
+                LabeledContent("Sidebar Max Expansion Depth") {
+                    Stepper(
+                        "",
+                        value: $settings.sidebarMaxExpansionDepth.asDouble,
+                        in: 1...20,
+                        step: 1,
+                        format: .number.precision(.fractionLength(0))
+                    )
+                    .labelsHidden()
+                }
+            } header: {
+                Text("Sidebar")
+            } footer: {
+                Text("Limits how deep a double-click recursively expands a node in the sidebar. Higher values expand more, but may briefly freeze the main thread on very large subtrees (e.g. the dyld shared cache root).")
+            }
         }
+    }
+}
+
+extension Binding where Value: BinaryInteger {
+    var asDouble: Binding<Double> {
+        Binding<Double>(
+            get: { Double(self.wrappedValue) },
+            set: { self.wrappedValue = Value($0.rounded()) }
+        )
     }
 }
 

--- a/RuntimeViewerPackages/Sources/RuntimeViewerSettingsUI/Components/IndexingSettingsView.swift
+++ b/RuntimeViewerPackages/Sources/RuntimeViewerSettingsUI/Components/IndexingSettingsView.swift
@@ -21,14 +21,10 @@ struct IndexingSettingsView: View {
             }
 
             Section {
-                Stepper(value: $indexing.backgroundMode.depth, in: 1...5) {
-                    LabeledContent("Depth", value: "\(indexing.backgroundMode.depth)")
-                }
+                Stepper("Depth", value: $indexing.backgroundMode.depth.asDouble, in: 1...5, format: .number.precision(.fractionLength(0)))
                 .disabled(!indexing.backgroundMode.isEnabled)
 
-                Stepper(value: $indexing.backgroundMode.maxConcurrency, in: 1...Self.maxConcurrencyUpperBound) {
-                    LabeledContent("Max Concurrent Tasks", value: "\(indexing.backgroundMode.maxConcurrency)")
-                }
+                Stepper("Max Concurrent Tasks", value: $indexing.backgroundMode.maxConcurrency.asDouble, in: 1...Self.maxConcurrencyUpperBound.double, format: .number.precision(.fractionLength(0)))
                 .disabled(!indexing.backgroundMode.isEnabled)
             } footer: {
                 Text("Depth controls how many levels of dependencies to index starting from each root image. Max concurrent tasks limits how many images are indexed in parallel; higher values finish faster but use more CPU.")

--- a/RuntimeViewerPackages/Sources/RuntimeViewerUI/AppKit/SelfSizingScrollView.swift
+++ b/RuntimeViewerPackages/Sources/RuntimeViewerUI/AppKit/SelfSizingScrollView.swift
@@ -9,19 +9,11 @@ import UIFoundation
 /// `lessThanOrEqualTo` constraint) caps the size. Once the document exceeds
 /// the cap, the built-in scrollers take over.
 open class SelfSizingScrollView: ScrollView {
-    public var minimumContentSize: NSSize = NSSize(width: NSView.noIntrinsicMetric, height: NSView.noIntrinsicMetric) {
-        didSet {
-            guard oldValue != minimumContentSize else { return }
-            invalidateIntrinsicContentSize()
-        }
-    }
+    @ViewInvalidating(.intrinsicContentSize)
+    public var minimumContentSize = NSSize(width: NSView.noIntrinsicMetric, height: NSView.noIntrinsicMetric)
 
-    public var maximumContentSize: NSSize = NSSize(width: NSView.noIntrinsicMetric, height: NSView.noIntrinsicMetric) {
-        didSet {
-            guard oldValue != maximumContentSize else { return }
-            invalidateIntrinsicContentSize()
-        }
-    }
+    @ViewInvalidating(.intrinsicContentSize)
+    public var maximumContentSize = NSSize(width: NSView.noIntrinsicMetric, height: NSView.noIntrinsicMetric)
 
     open override var intrinsicContentSize: NSSize {
         guard let documentView else { return super.intrinsicContentSize }

--- a/RuntimeViewerPackages/Sources/RuntimeViewerUI/RuntimeViewerUI.swift
+++ b/RuntimeViewerPackages/Sources/RuntimeViewerUI/RuntimeViewerUI.swift
@@ -1,5 +1,4 @@
 @_exported import SnapKit
-@_exported import NSAttributedStringBuilder
 @_exported import SFSymbols
 @_exported import UIFoundation
 @_exported import UIFoundationToolbox
@@ -12,7 +11,6 @@
 #endif
 @_exported import RunningApplicationKit
 @_exported import Rearrange
-//@_exported import DSFQuickActionBar
 @_exported import SystemHUD
 #endif
 

--- a/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit.xcodeproj/project.pbxproj
+++ b/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		E96BF91D2F60541F009C40D2 /* MCPStatusPopoverViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E96BF91C2F60541F009C40D2 /* MCPStatusPopoverViewModel.swift */; };
 		E96CF5332EC7A4A600CBC159 /* RuntimeSource+.swift in Sources */ = {isa = PBXBuildFile; fileRef = E96CF5322EC7A4A600CBC159 /* RuntimeSource+.swift */; };
 		E96DE1E32F0ACE8D00F9BAB2 /* CheckboxButton+.swift in Sources */ = {isa = PBXBuildFile; fileRef = E96DE1E22F0ACE8D00F9BAB2 /* CheckboxButton+.swift */; };
+		E9720F822FC17FA0003AAEA6 /* NSOutlineView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9720F812FC17FA0003AAEA6 /* NSOutlineView+.swift */; };
 		E975449A2C42BA5B00CC9DDD /* LoadFrameworksViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = E97544992C42BA5B00CC9DDD /* LoadFrameworksViewController.xib */; };
 		E975449B2C42BA5B00CC9DDD /* LoadFrameworksViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E97544982C42BA5B00CC9DDD /* LoadFrameworksViewController.swift */; };
 		E97544A42C42D11C00CC9DDD /* GenerationOptionsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E97544A32C42D11C00CC9DDD /* GenerationOptionsViewModel.swift */; };
@@ -274,6 +275,7 @@
 		E96BF91C2F60541F009C40D2 /* MCPStatusPopoverViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPStatusPopoverViewModel.swift; sourceTree = "<group>"; };
 		E96CF5322EC7A4A600CBC159 /* RuntimeSource+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RuntimeSource+.swift"; sourceTree = "<group>"; };
 		E96DE1E22F0ACE8D00F9BAB2 /* CheckboxButton+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CheckboxButton+.swift"; sourceTree = "<group>"; };
+		E9720F812FC17FA0003AAEA6 /* NSOutlineView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSOutlineView+.swift"; sourceTree = "<group>"; };
 		E97544982C42BA5B00CC9DDD /* LoadFrameworksViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadFrameworksViewController.swift; sourceTree = "<group>"; };
 		E97544992C42BA5B00CC9DDD /* LoadFrameworksViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = LoadFrameworksViewController.xib; sourceTree = "<group>"; };
 		E97544A32C42D11C00CC9DDD /* GenerationOptionsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerationOptionsViewModel.swift; sourceTree = "<group>"; };
@@ -652,6 +654,7 @@
 				E9530A3B2D9D5898008FBC7F /* SIPChecker.swift */,
 				E96CF5322EC7A4A600CBC159 /* RuntimeSource+.swift */,
 				E96DE1E22F0ACE8D00F9BAB2 /* CheckboxButton+.swift */,
+				E9720F812FC17FA0003AAEA6 /* NSOutlineView+.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -997,6 +1000,7 @@
 				E9A8253A2C0E095500D9A85D /* SidebarRuntimeObjectViewController.swift in Sources */,
 				E9EB37AC2C397024003E2859 /* InspectorClassViewController.swift in Sources */,
 				E99AE0BC2CBD4A840028B11E /* Document.swift in Sources */,
+				E9720F822FC17FA0003AAEA6 /* NSOutlineView+.swift in Sources */,
 				E943301C2C0DB75B00362862 /* Then.swift in Sources */,
 				E9AA36222C3089AB00A9B2E4 /* InspectorPlaceholderViewController.swift in Sources */,
 				E921246F2F447BE1007481E4 /* ExportingProgressViewModel.swift in Sources */,

--- a/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit/Sidebar/Root/SidebarRootViewController.swift
+++ b/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit/Sidebar/Root/SidebarRootViewController.swift
@@ -15,8 +15,6 @@ class SidebarRootViewController<ViewModel: SidebarRootViewModel>: UXKitViewContr
 
     private let bottomSeparatorView = NSBox()
 
-    private var delegate: OutlineViewDelegate?
-
     override var shouldDisplayCommonLoading: Bool {
         true
     }
@@ -73,8 +71,6 @@ class SidebarRootViewController<ViewModel: SidebarRootViewModel>: UXKitViewContr
     override func setupBindings(for viewModel: ViewModel) {
         super.setupBindings(for: viewModel)
 
-        delegate = .init(viewModel: viewModel)
-
         let input = ViewModel.Input(
             clickedNode: outlineView.rx.modelDoubleClicked().asSignal(),
             selectedNode: outlineView.rx.modelSelected().asSignal(),
@@ -120,9 +116,8 @@ class SidebarRootViewController<ViewModel: SidebarRootViewModel>: UXKitViewContr
             .first()
             .asObservable()
             .subscribeOnNext { [weak self] _ in
-                guard let self, let delegate else { return }
-
-                outlineView.rx.setDelegate(delegate).disposed(by: rx.disposeBag)
+                guard let self else { return }
+                
                 outlineView.identifier = "com.JH.RuntimeViewer.\(Self.self).identifier.\(viewModel.documentState.runtimeEngine.source.description)"
 
                 // Manual expansion autosave: NSOutlineView's built-in
@@ -146,22 +141,15 @@ class SidebarRootViewController<ViewModel: SidebarRootViewModel>: UXKitViewContr
             }
             .disposed(by: rx.disposeBag)
         
-        output.expandItem
-            .emitOnNextMainActor { [weak self] viewModel in
+        output.toggleExpansion
+            .emitOnNextMainActor { [weak self] item, maxDepth in
                 guard let self else { return }
-                outlineView.expandItem(viewModel, expandChildren: true)
+                if outlineView.isItemExpanded(item) {
+                    outlineView.collapseItem(item)
+                } else {
+                    outlineView.expandItem(item, toDepth: maxDepth)
+                }
             }
             .disposed(by: rx.disposeBag)
-    }
-}
-
-extension SidebarRootViewController {
-    private final class OutlineViewDelegate: NSObject, NSOutlineViewDelegate {
-        private unowned let viewModel: ViewModel
-
-        init(viewModel: ViewModel) {
-            self.viewModel = viewModel
-            super.init()
-        }
     }
 }

--- a/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit/Sidebar/Root/SidebarRootViewController.swift
+++ b/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit/Sidebar/Root/SidebarRootViewController.swift
@@ -145,6 +145,13 @@ class SidebarRootViewController<ViewModel: SidebarRootViewModel>: UXKitViewContr
                 outlineView.restoreExpansionFromAutosave()
             }
             .disposed(by: rx.disposeBag)
+        
+        output.expandItem
+            .emitOnNextMainActor { [weak self] viewModel in
+                guard let self else { return }
+                outlineView.expandItem(viewModel, expandChildren: true)
+            }
+            .disposed(by: rx.disposeBag)
     }
 }
 

--- a/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit/Utils/CheckboxButton+.swift
+++ b/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit/Utils/CheckboxButton+.swift
@@ -1,6 +1,5 @@
 import AppKit
 import UIFoundation
-import NSAttributedStringBuilder
 
 extension CheckboxButton {
     convenience init(title: String, titleFont: NSFont? = nil, titleColor: NSColor? = nil, titleSpacing: CGFloat = 5.0) {

--- a/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit/Utils/NSOutlineView+.swift
+++ b/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit/Utils/NSOutlineView+.swift
@@ -1,0 +1,24 @@
+import AppKit
+
+extension NSOutlineView {
+    /// Expands the given item and its descendants down to the specified depth.
+    ///
+    /// Complements AppKit's `expandItem(_:expandChildren:)`, which can only expand a single
+    /// level or every descendant. Pass `depth` to cap the recursion at a fixed number of levels.
+    ///
+    /// - Parameters:
+    ///   - item: The item to expand, or `nil` to expand the outline view's root items.
+    ///   - depth: The number of levels to expand, counting `item` itself as level `1`. A value
+    ///     of `1` expands only `item`; `2` also expands its direct children, and so on. Values
+    ///     of `0` or below perform no expansion.
+    func expandItem(_ item: Any?, toDepth depth: Int) {
+        guard depth > 0 else { return }
+        expandItem(item)
+        guard let dataSource else { return }
+        let childCount = dataSource.outlineView?(self, numberOfChildrenOfItem: item) ?? 0
+        for childIndex in 0..<childCount {
+            guard let childItem = dataSource.outlineView?(self, child: childIndex, ofItem: item) else { continue }
+            expandItem(childItem, toDepth: depth - 1)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Small standalone improvements split out of the wider refactor branch.

- **refactor(ui)** `0997f20` — `SelfSizingScrollView.minimumContentSize` / `maximumContentSize` now use `@ViewInvalidating(.intrinsicContentSize)` (UIFoundation), replacing the hand-rolled `didSet` invalidation pattern.
- **chore(deps)** `aaf893c` — drops the standalone `NSAttributedStringBuilder` SPM dependency and routes it through the `UIFoundation` `NSAttributedStringBuilder` trait, so `RuntimeViewerUI` no longer has to `@_exported import` it directly.
- **feat(sidebar)** `f2c9852` — single-click on a non-leaf sidebar node now toggles expansion. Previously double-click was the only path.
- **feat(sidebar)** `80edfea` — adds `Settings.General.sidebarMaxExpansionDepth` (default `3`, range `1...20`) to cap `expandItem(_:expandChildren: true)` recursion. Without the cap, double-clicking the dyld shared cache root freezes the main thread while AppKit walks every descendant. Exposes a Stepper in the General settings pane.

## Test plan
- [ ] `swift build` in `RuntimeViewerCore` succeeds.
- [ ] Workspace build of `RuntimeViewer macOS` succeeds.
- [ ] Manual: open the sidebar, single-click a non-leaf row, confirm it toggles.
- [ ] Manual: set sidebar max expansion depth to 1 vs 5 in Settings → General, double-click dyld shared cache, confirm depth caps.
- [ ] Manual: verify Settings → Indexing 'Depth' / 'Max Concurrent Tasks' Steppers still render and edit correctly (touched indirectly by the binding helper).

Split from #62.