### PR TITLE
refactor: state-driven navigation via DocumentState.selectionRouter

### DIFF
--- a/RuntimeViewerPackages/Sources/RuntimeViewerApplication/DocumentState.swift
+++ b/RuntimeViewerPackages/Sources/RuntimeViewerApplication/DocumentState.swift
@@ -17,8 +17,25 @@ public final class DocumentState {
     @Observed
     public var runtimeEngine: RuntimeEngine = .local
 
+    /// Navigation stack of runtime objects currently under inspection.
+    ///
+    /// - Empty: nothing selected (Content / Inspector show placeholder).
+    /// - One element: root inspection of that object.
+    /// - Multiple elements: user drilled into related objects from the Inspector
+    ///   relationships tab. The last element is the active selection;
+    ///   preceding elements are ancestors on the back stack.
+    ///
+    /// All UI panes (Sidebar visual selection, Content navigation stack,
+    /// Inspector navigation stack) derive their state from this single
+    /// source. Mutations enter through ViewModels / Coordinators that own
+    /// user input (Sidebar row click, Inspector relationship click, Content
+    /// back button, etc.).
     @Observed
-    public var selectedRuntimeObject: RuntimeObject?
+    public var selectionStack: [RuntimeObject] = []
+
+    /// Read-only derived view of `selectionStack.last`. Mutations go through
+    /// explicit `selectionStack` operations (push / pop / reset / append).
+    public var selectedRuntimeObject: RuntimeObject? { selectionStack.last }
 
     @Observed
     public var currentImageNode: RuntimeImageNode?

--- a/RuntimeViewerPackages/Sources/RuntimeViewerApplication/DocumentState.swift
+++ b/RuntimeViewerPackages/Sources/RuntimeViewerApplication/DocumentState.swift
@@ -7,42 +7,87 @@ import RuntimeViewerArchitectures
 public final class DocumentState {
     public init() {}
 
-    /// The runtime engine backing this Document.
+    /// The runtime engine backing this Document. Read-only externally:
+    /// mutated only via the `.switchEngine` route. `MainCoordinator` is
+    /// responsible for issuing that route from its `.main` handler — the
+    /// trigger also atomically clears `currentImageNode` and
+    /// `selectionStack` so consumers never observe a half-switched state.
     ///
-    /// Reassignable: `MainCoordinator` swaps this when the user changes source
-    /// (Local ↔ XPC ↔ Bonjour). `RuntimeBackgroundIndexingCoordinator`
-    /// subscribes to `$runtimeEngine` and rewires its pumps onto the new
-    /// engine's `backgroundIndexingManager`, cancelling the old engine's
-    /// in-flight document batches as it goes.
+    /// `RuntimeBackgroundIndexingCoordinator` subscribes to `$runtimeEngine`
+    /// and rewires its pumps onto the new engine's `backgroundIndexingManager`,
+    /// cancelling the old engine's in-flight document batches as it goes.
     @Observed
-    public var runtimeEngine: RuntimeEngine = .local
+    public private(set) var runtimeEngine: RuntimeEngine = .local
+
+    /// Currently inspected runtime image. `nil` when the sidebar is at the
+    /// image-picker root. Read-only externally: mutated only via the
+    /// `.switchImage` route.
+    @Observed
+    public private(set) var currentImageNode: RuntimeImageNode?
 
     /// Navigation stack of runtime objects currently under inspection.
     ///
-    /// - Empty: nothing selected (Content / Inspector show placeholder).
+    /// - Empty: nothing selected (content / inspector show placeholder).
     /// - One element: root inspection of that object.
-    /// - Multiple elements: user drilled into related objects from the Inspector
-    ///   relationships tab. The last element is the active selection;
-    ///   preceding elements are ancestors on the back stack.
+    /// - Multiple elements: user drilled into related objects from the
+    ///   inspector relationships tab. The last element is the active
+    ///   selection; preceding elements are ancestors on the back stack.
     ///
-    /// All UI panes (Sidebar visual selection, Content navigation stack,
-    /// Inspector navigation stack) derive their state from this single
-    /// source. Mutations enter through ViewModels / Coordinators that own
-    /// user input (Sidebar row click, Inspector relationship click, Content
-    /// back button, etc.).
+    /// Read-only externally: every mutation goes through `selectionRouter`,
+    /// which dispatches a typed `SelectionRoute` and emits to
+    /// `routeSignal` after the state update has been applied.
     @Observed
-    public var selectionStack: [RuntimeObject] = []
+    public private(set) var selectionStack: [RuntimeObject] = []
 
-    /// Read-only derived view of `selectionStack.last`. Mutations go through
-    /// explicit `selectionStack` operations (push / pop / reset / append).
+    /// Top of `selectionStack` — the object currently shown by content /
+    /// inspector. Mutations go through explicit selection routes
+    /// (`selectAtRoot`, `drillInto`, `pop`, `clear`).
     public var selectedRuntimeObject: RuntimeObject? { selectionStack.last }
 
-    @Observed
-    public var currentImageNode: RuntimeImageNode?
+    /// Mutation surface for every observable state on this `DocumentState`.
+    /// View models trigger routes on this router
+    /// (`documentState.selectionRouter.trigger(.drillInto(x))`). The router
+    /// applies the state mutation synchronously, then emits to
+    /// `routeSignal` so scene-level subscribers (`MainCoordinator`) can
+    /// fan out to their child coordinators.
+    public private(set) lazy var selectionRouter: any Router<SelectionRoute> = SelectionRouter(documentState: self)
+
+    /// Hot stream of selection routes. Emits **after** the corresponding
+    /// state update on this `DocumentState` has been applied, so subscribers
+    /// observe the post-mutation snapshot when handling a route. Hot —
+    /// new subscribers do not see past routes.
+    public var routeSignal: Signal<SelectionRoute> { routeRelay.asSignal() }
+
+    private let routeRelay = PublishRelay<SelectionRoute>()
+
+    fileprivate func apply(_ route: SelectionRoute) {
+        switch route {
+        case .switchEngine(let engine):
+            if runtimeEngine === engine, currentImageNode == nil, selectionStack.isEmpty { return }
+            runtimeEngine = engine
+            currentImageNode = nil
+            selectionStack = []
+        case .switchImage(let node):
+            if currentImageNode == node, selectionStack.isEmpty { return }
+            currentImageNode = node
+            selectionStack = []
+        case .selectAtRoot(let object):
+            selectionStack = [object]
+        case .drillInto(let object):
+            selectionStack.append(object)
+        case .pop:
+            guard !selectionStack.isEmpty else { return }
+            selectionStack.removeLast()
+        case .clear:
+            guard !selectionStack.isEmpty else { return }
+            selectionStack = []
+        }
+        routeRelay.accept(route)
+    }
 
     @Observed
     public var currentSubtitle: String = ""
-    
+
     /// Per-Document background indexing coordinator.
     ///
     /// Force-initialized on the first Document lifecycle hook
@@ -57,4 +102,28 @@ public final class DocumentState {
     /// a new engine via the `$runtimeEngine` subscription on every source
     /// switch — see that property's doc comment for the swap contract.
     public private(set) lazy var backgroundIndexingCoordinator = RuntimeBackgroundIndexingCoordinator(documentState: self)
+}
+
+private final class SelectionRouter: Router {
+    typealias Route = SelectionRoute
+
+    private unowned let documentState: DocumentState
+
+    init(documentState: DocumentState) {
+        self.documentState = documentState
+    }
+
+    func contextTrigger(
+        _ route: SelectionRoute,
+        with options: TransitionOptions,
+        completion: ContextPresentationHandler?
+    ) {
+        documentState.apply(route)
+        completion?(EmptyRouteTransitionContext.shared)
+    }
+}
+
+private struct EmptyRouteTransitionContext: TransitionContext {
+    static let shared = EmptyRouteTransitionContext()
+    var presentables: [any Presentable] { [] }
 }

--- a/RuntimeViewerPackages/Sources/RuntimeViewerApplication/DocumentState.swift
+++ b/RuntimeViewerPackages/Sources/RuntimeViewerApplication/DocumentState.swift
@@ -17,13 +17,13 @@ public final class DocumentState {
     /// and rewires its pumps onto the new engine's `backgroundIndexingManager`,
     /// cancelling the old engine's in-flight document batches as it goes.
     @Observed
-    public private(set) var runtimeEngine: RuntimeEngine = .local
+    public fileprivate(set) var runtimeEngine: RuntimeEngine = .local
 
     /// Currently inspected runtime image. `nil` when the sidebar is at the
     /// image-picker root. Read-only externally: mutated only via the
     /// `.switchImage` route.
     @Observed
-    public private(set) var currentImageNode: RuntimeImageNode?
+    public fileprivate(set) var currentImageNode: RuntimeImageNode?
 
     /// Navigation stack of runtime objects currently under inspection.
     ///
@@ -37,7 +37,7 @@ public final class DocumentState {
     /// which dispatches a typed `SelectionRoute` and emits to
     /// `routeSignal` after the state update has been applied.
     @Observed
-    public private(set) var selectionStack: [RuntimeObject] = []
+    public fileprivate(set) var selectionStack: [RuntimeObject] = []
 
     /// Top of `selectionStack` — the object currently shown by content /
     /// inspector. Mutations go through explicit selection routes
@@ -50,40 +50,15 @@ public final class DocumentState {
     /// applies the state mutation synchronously, then emits to
     /// `routeSignal` so scene-level subscribers (`MainCoordinator`) can
     /// fan out to their child coordinators.
-    public private(set) lazy var selectionRouter: any Router<SelectionRoute> = SelectionRouter(documentState: self)
+    public var selectionRouter: any Router<SelectionRoute> { _selectionRouter }
 
     /// Hot stream of selection routes. Emits **after** the corresponding
     /// state update on this `DocumentState` has been applied, so subscribers
     /// observe the post-mutation snapshot when handling a route. Hot —
     /// new subscribers do not see past routes.
-    public var routeSignal: Signal<SelectionRoute> { routeRelay.asSignal() }
-
-    private let routeRelay = PublishRelay<SelectionRoute>()
-
-    fileprivate func apply(_ route: SelectionRoute) {
-        switch route {
-        case .switchEngine(let engine):
-            if runtimeEngine === engine, currentImageNode == nil, selectionStack.isEmpty { return }
-            runtimeEngine = engine
-            currentImageNode = nil
-            selectionStack = []
-        case .switchImage(let node):
-            if currentImageNode == node, selectionStack.isEmpty { return }
-            currentImageNode = node
-            selectionStack = []
-        case .selectAtRoot(let object):
-            selectionStack = [object]
-        case .drillInto(let object):
-            selectionStack.append(object)
-        case .pop:
-            guard !selectionStack.isEmpty else { return }
-            selectionStack.removeLast()
-        case .clear:
-            guard !selectionStack.isEmpty else { return }
-            selectionStack = []
-        }
-        routeRelay.accept(route)
-    }
+    public var routeSignal: Signal<SelectionRoute> { _selectionRouter.routeRelay.asSignal() }
+    
+    private lazy var _selectionRouter = SelectionRouter(documentState: self)
 
     @Observed
     public var currentSubtitle: String = ""
@@ -107,8 +82,10 @@ public final class DocumentState {
 private final class SelectionRouter: Router {
     typealias Route = SelectionRoute
 
-    private unowned let documentState: DocumentState
-
+    unowned let documentState: DocumentState
+    
+    let routeRelay = PublishRelay<SelectionRoute>()
+    
     init(documentState: DocumentState) {
         self.documentState = documentState
     }
@@ -118,7 +95,28 @@ private final class SelectionRouter: Router {
         with options: TransitionOptions,
         completion: ContextPresentationHandler?
     ) {
-        documentState.apply(route)
+        switch route {
+        case .switchEngine(let engine):
+            if documentState.runtimeEngine === engine, documentState.currentImageNode == nil, documentState.selectionStack.isEmpty { return }
+            documentState.runtimeEngine = engine
+            documentState.currentImageNode = nil
+            documentState.selectionStack = []
+        case .switchImage(let node):
+            if documentState.currentImageNode == node, documentState.selectionStack.isEmpty { return }
+            documentState.currentImageNode = node
+            documentState.selectionStack = []
+        case .selectAtRoot(let object):
+            documentState.selectionStack = [object]
+        case .drillInto(let object):
+            documentState.selectionStack.append(object)
+        case .pop:
+            guard !documentState.selectionStack.isEmpty else { return }
+            documentState.selectionStack.removeLast()
+        case .clear:
+            guard !documentState.selectionStack.isEmpty else { return }
+            documentState.selectionStack = []
+        }
+        routeRelay.accept(route)
         completion?(EmptyRouteTransitionContext.shared)
     }
 }

--- a/RuntimeViewerPackages/Sources/RuntimeViewerApplication/Inspector/InspectorRelationshipsViewModel.swift
+++ b/RuntimeViewerPackages/Sources/RuntimeViewerApplication/Inspector/InspectorRelationshipsViewModel.swift
@@ -43,7 +43,7 @@ public final class InspectorRelationshipsViewModel: ViewModel<InspectorRuntimeOb
     public func transform(_ input: Input) -> Output {
         input.selectRelationshipClicked.emitOnNext { [weak self] cellViewModel in
             guard let self else { return }
-            documentState.selectionStack.append(cellViewModel.runtimeObject)
+            documentState.selectionRouter.trigger(.drillInto(cellViewModel.runtimeObject))
         }
         .disposed(by: rx.disposeBag)
 

--- a/RuntimeViewerPackages/Sources/RuntimeViewerApplication/Inspector/InspectorRelationshipsViewModel.swift
+++ b/RuntimeViewerPackages/Sources/RuntimeViewerApplication/Inspector/InspectorRelationshipsViewModel.swift
@@ -43,7 +43,7 @@ public final class InspectorRelationshipsViewModel: ViewModel<InspectorRuntimeOb
     public func transform(_ input: Input) -> Output {
         input.selectRelationshipClicked.emitOnNext { [weak self] cellViewModel in
             guard let self else { return }
-            router.trigger(.selectRuntimeObject(cellViewModel.runtimeObject))
+            documentState.selectionStack.append(cellViewModel.runtimeObject)
         }
         .disposed(by: rx.disposeBag)
 

--- a/RuntimeViewerPackages/Sources/RuntimeViewerApplication/Inspector/InspectorRoute.swift
+++ b/RuntimeViewerPackages/Sources/RuntimeViewerApplication/Inspector/InspectorRoute.swift
@@ -29,9 +29,6 @@ public enum InspectorRuntimeObjectRoute: Routable {
     /// `InspectorRoute.requestSpecializationSheet` on itself, which
     /// `MainCoordinator` already listens for.
     case requestSpecializationSheet(RuntimeObject)
-    /// Forwarded up to `InspectorCoordinator` so it can re-trigger
-    /// `InspectorRoute.selectRuntimeObject` on itself.
-    case selectRuntimeObject(RuntimeObject)
 }
 #else
 public typealias InspectorRuntimeObjectRoute = InspectorRoute

--- a/RuntimeViewerPackages/Sources/RuntimeViewerApplication/Inspector/InspectorSwiftSpecializationViewModel.swift
+++ b/RuntimeViewerPackages/Sources/RuntimeViewerApplication/Inspector/InspectorSwiftSpecializationViewModel.swift
@@ -31,7 +31,7 @@ public final class InspectorSwiftSpecializationViewModel: ViewModel<InspectorRun
 
         input.selectSpecializationClicked.emitOnNext { [weak self] cellViewModel in
             guard let self else { return }
-            documentState.selectionStack.append(cellViewModel.runtimeObject)
+            documentState.selectionRouter.trigger(.drillInto(cellViewModel.runtimeObject))
         }
         .disposed(by: rx.disposeBag)
 

--- a/RuntimeViewerPackages/Sources/RuntimeViewerApplication/Inspector/InspectorSwiftSpecializationViewModel.swift
+++ b/RuntimeViewerPackages/Sources/RuntimeViewerApplication/Inspector/InspectorSwiftSpecializationViewModel.swift
@@ -31,7 +31,7 @@ public final class InspectorSwiftSpecializationViewModel: ViewModel<InspectorRun
 
         input.selectSpecializationClicked.emitOnNext { [weak self] cellViewModel in
             guard let self else { return }
-            router.trigger(.selectRuntimeObject(cellViewModel.runtimeObject))
+            documentState.selectionStack.append(cellViewModel.runtimeObject)
         }
         .disposed(by: rx.disposeBag)
 

--- a/RuntimeViewerPackages/Sources/RuntimeViewerApplication/SelectionRoute.swift
+++ b/RuntimeViewerPackages/Sources/RuntimeViewerApplication/SelectionRoute.swift
@@ -1,0 +1,37 @@
+import Foundation
+import FoundationToolbox
+import RuntimeViewerCore
+import RuntimeViewerArchitectures
+
+/// Document-scoped navigation routes.
+///
+/// `SelectionRoute` is the shared vocabulary that lets sidebar / content /
+/// inspector view models express what the user wants to happen without
+/// knowing about each other or about `MainCoordinator`. Routes are
+/// triggered on `DocumentState.selectionRouter`, applied atomically to
+/// `DocumentState`, and then emitted on `routeSignal` so scene-level
+/// subscribers (`MainCoordinator`) can fan out to their child coordinators.
+///
+/// Each case represents a single, atomic mutation:
+/// - `switchEngine`: replace the backing runtime engine and clear any
+///   in-flight image / selection state. Triggered from `MainCoordinator`'s
+///   `.main` route handler.
+/// - `switchImage`: change the currently inspected image, atomically
+///   clearing any in-flight drill-down stack (sidebar image click, sidebar
+///   back).
+/// - `selectAtRoot`: replace the entire inspection stack with one object
+///   (sidebar row click, specialization completion).
+/// - `drillInto`: push one object onto the stack (inspector relationship /
+///   specialization child click).
+/// - `pop`: remove the topmost object (toolbar content back).
+/// - `clear`: empty the stack but keep `currentImageNode`.
+@AssociatedValue(.public)
+@CaseCheckable(.public)
+public enum SelectionRoute: Routable {
+    case switchEngine(RuntimeEngine)
+    case switchImage(RuntimeImageNode?)
+    case selectAtRoot(RuntimeObject)
+    case drillInto(RuntimeObject)
+    case pop
+    case clear
+}

--- a/RuntimeViewerPackages/Sources/RuntimeViewerApplication/Sidebar/SidebarRootViewModel.swift
+++ b/RuntimeViewerPackages/Sources/RuntimeViewerApplication/Sidebar/SidebarRootViewModel.swift
@@ -99,7 +99,7 @@ public class SidebarRootViewModel: ViewModel<SidebarRootRoute> {
 
             if viewModel.node.isLeaf {
                 #if os(macOS)
-                documentState.currentImageNode = viewModel.node
+                documentState.selectionRouter.trigger(.switchImage(viewModel.node))
                 #else
                 self.router.trigger(.clickedNode(viewModel.node))
                 #endif

--- a/RuntimeViewerPackages/Sources/RuntimeViewerApplication/Sidebar/SidebarRootViewModel.swift
+++ b/RuntimeViewerPackages/Sources/RuntimeViewerApplication/Sidebar/SidebarRootViewModel.swift
@@ -99,7 +99,7 @@ public class SidebarRootViewModel: ViewModel<SidebarRootRoute> {
 
             if viewModel.node.isLeaf {
                 #if os(macOS)
-                self.router.trigger(.image(viewModel.node))
+                documentState.currentImageNode = viewModel.node
                 #else
                 self.router.trigger(.clickedNode(viewModel.node))
                 #endif

--- a/RuntimeViewerPackages/Sources/RuntimeViewerApplication/Sidebar/SidebarRoutes.swift
+++ b/RuntimeViewerPackages/Sources/RuntimeViewerApplication/Sidebar/SidebarRoutes.swift
@@ -20,7 +20,6 @@ public enum SidebarRootRoute: Routable {
     case initial
     case directory
     case bookmarks
-    case image(RuntimeImageNode)
 }
 @AssociatedValue(.public)
 @CaseCheckable(.public)
@@ -28,7 +27,6 @@ public enum SidebarRuntimeObjectRoute: Routable {
     case initial
     case objects
     case bookmarks
-    case selectedObject(RuntimeObject)
 }
 #else
 public typealias SidebarRootRoute = SidebarRoute

--- a/RuntimeViewerPackages/Sources/RuntimeViewerApplication/Sidebar/SidebarRuntimeObjectListViewModel.swift
+++ b/RuntimeViewerPackages/Sources/RuntimeViewerApplication/Sidebar/SidebarRuntimeObjectListViewModel.swift
@@ -119,7 +119,7 @@ public final class SidebarRuntimeObjectListViewModel: SidebarRuntimeObjectViewMo
             .emitOnNextMainActor { [weak self] viewModel in
                 guard let self else { return }
                 #if os(macOS)
-                documentState.selectionStack = [viewModel.runtimeObject]
+                documentState.selectionRouter.trigger(.selectAtRoot(viewModel.runtimeObject))
                 #else
                 self.router.trigger(.selectedObject(viewModel.runtimeObject))
                 #endif

--- a/RuntimeViewerPackages/Sources/RuntimeViewerApplication/Sidebar/SidebarRuntimeObjectListViewModel.swift
+++ b/RuntimeViewerPackages/Sources/RuntimeViewerApplication/Sidebar/SidebarRuntimeObjectListViewModel.swift
@@ -118,7 +118,11 @@ public final class SidebarRuntimeObjectListViewModel: SidebarRuntimeObjectViewMo
         input.runtimeObjectClickedForOpenQuickly
             .emitOnNextMainActor { [weak self] viewModel in
                 guard let self else { return }
+                #if os(macOS)
+                documentState.selectionStack = [viewModel.runtimeObject]
+                #else
                 self.router.trigger(.selectedObject(viewModel.runtimeObject))
+                #endif
             }
             .disposed(by: rx.disposeBag)
 

--- a/RuntimeViewerPackages/Sources/RuntimeViewerApplication/Sidebar/SidebarRuntimeObjectListViewModel.swift
+++ b/RuntimeViewerPackages/Sources/RuntimeViewerApplication/Sidebar/SidebarRuntimeObjectListViewModel.swift
@@ -11,16 +11,16 @@ public final class SidebarRuntimeObjectListViewModel: SidebarRuntimeObjectViewMo
     @Observed public private(set) var filteredNodesForOpenQuickly: [SidebarRuntimeObjectCellViewModel] = []
     @Observed public private(set) var isFilteringForOpenQuickly: Bool = false
 
+    /// Latest non-nil root object the document is inspecting, waiting to
+    /// be resolved to a concrete cell once it appears in `nodes`. Driven
+    /// by `documentState.$selectionStack` (see `transform`) — never by an
+    /// external imperative call.
     private let pendingSelectRelay = PublishRelay<RuntimeObject>()
 
     override var isSorted: Bool { true }
 
     public override init(imageNode: RuntimeImageNode, documentState: DocumentState, router: any Router<SidebarRuntimeObjectRoute>) {
         super.init(imageNode: imageNode, documentState: documentState, router: router)
-    }
-
-    public func selectRuntimeObject(_ object: RuntimeObject) {
-        pendingSelectRelay.accept(object)
     }
 
     public static func findCell(
@@ -124,6 +124,19 @@ public final class SidebarRuntimeObjectListViewModel: SidebarRuntimeObjectViewMo
                 self.router.trigger(.selectedObject(viewModel.runtimeObject))
                 #endif
             }
+            .disposed(by: rx.disposeBag)
+
+        // Visual selection follows whatever the document is currently
+        // inspecting at its root. The sidebar row click path already
+        // dispatched `.selectAtRoot` through `documentState.selectionRouter`,
+        // so observing `selectionStack` covers both that case (idempotent
+        // re-select on the already-highlighted row) and the specialization-
+        // completion case (new root object that has not yet been clicked).
+        documentState.$selectionStack
+            .asObservable()
+            .compactMap { $0.first }
+            .distinctUntilChanged()
+            .bind(to: pendingSelectRelay)
             .disposed(by: rx.disposeBag)
 
         let pendingResolved: Signal<CellLookup> = pendingSelectRelay

--- a/RuntimeViewerPackages/Sources/RuntimeViewerApplication/Sidebar/SidebarRuntimeObjectViewModel.swift
+++ b/RuntimeViewerPackages/Sources/RuntimeViewerApplication/Sidebar/SidebarRuntimeObjectViewModel.swift
@@ -125,7 +125,11 @@ public class SidebarRuntimeObjectViewModel: ViewModel<SidebarRuntimeObjectRoute>
         input.runtimeObjectClicked
             .emitOnNextMainActor { [weak self] viewModel in
                 guard let self else { return }
+                #if os(macOS)
+                documentState.selectionStack = [viewModel.runtimeObject]
+                #else
                 self.router.trigger(.selectedObject(viewModel.runtimeObject))
+                #endif
             }
             .disposed(by: rx.disposeBag)
 

--- a/RuntimeViewerPackages/Sources/RuntimeViewerApplication/Sidebar/SidebarRuntimeObjectViewModel.swift
+++ b/RuntimeViewerPackages/Sources/RuntimeViewerApplication/Sidebar/SidebarRuntimeObjectViewModel.swift
@@ -126,7 +126,7 @@ public class SidebarRuntimeObjectViewModel: ViewModel<SidebarRuntimeObjectRoute>
             .emitOnNextMainActor { [weak self] viewModel in
                 guard let self else { return }
                 #if os(macOS)
-                documentState.selectionStack = [viewModel.runtimeObject]
+                documentState.selectionRouter.trigger(.selectAtRoot(viewModel.runtimeObject))
                 #else
                 self.router.trigger(.selectedObject(viewModel.runtimeObject))
                 #endif

--- a/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit/Content/ContentCoordinator.swift
+++ b/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit/Content/ContentCoordinator.swift
@@ -9,22 +9,9 @@ typealias ContentTransition = Transition<Void, ContentNavigationController>
 final class ContentCoordinator: ViewCoordinator<ContentRoute, ContentTransition> {
     let documentState: DocumentState
 
-    private let disposeBag = DisposeBag()
-
     init(documentState: DocumentState) {
         self.documentState = documentState
         super.init(rootViewController: .init(nibName: nil, bundle: nil), initialRoute: nil)
-
-        documentState.$selectionStack
-            .asObservable()
-            .scan((previous: nil as [RuntimeObject]?, current: documentState.selectionStack)) { state, next in
-                (previous: state.current, current: next)
-            }
-            .subscribeOnNext { [weak self] state in
-                guard let self else { return }
-                applyStackChange(previous: state.previous, current: state.current)
-            }
-            .disposed(by: disposeBag)
     }
 
     override func prepareTransition(for route: ContentRoute) -> ContentTransition {
@@ -50,42 +37,5 @@ final class ContentCoordinator: ViewCoordinator<ContentRoute, ContentTransition>
         viewController.setupBindings(for: viewModel)
         viewController.loadViewIfNeeded()
         return viewController
-    }
-
-    private func applyStackChange(previous: [RuntimeObject]?, current: [RuntimeObject]) {
-        guard let previous else {
-            installStack(current)
-            return
-        }
-        if previous == current { return }
-
-        if current.isEmpty {
-            trigger(.placeholder)
-            return
-        }
-        if previous.isEmpty {
-            installStack(current)
-            return
-        }
-        if current.count == previous.count + 1, Array(current.prefix(previous.count)) == previous {
-            trigger(.next(current.last!))
-            return
-        }
-        if previous.count == current.count + 1, Array(previous.prefix(current.count)) == current {
-            trigger(.back)
-            return
-        }
-        installStack(current)
-    }
-
-    private func installStack(_ stack: [RuntimeObject]) {
-        if stack.isEmpty {
-            trigger(.placeholder)
-            return
-        }
-        trigger(.root(stack[0]))
-        for runtimeObject in stack.dropFirst() {
-            trigger(.next(runtimeObject))
-        }
     }
 }

--- a/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit/Content/ContentCoordinator.swift
+++ b/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit/Content/ContentCoordinator.swift
@@ -7,26 +7,24 @@ import RuntimeViewerApplication
 typealias ContentTransition = Transition<Void, ContentNavigationController>
 
 final class ContentCoordinator: ViewCoordinator<ContentRoute, ContentTransition> {
-    protocol Delegate: AnyObject {
-        func contentCoordinatorDidShowPlaceholder(_ coordinator: ContentCoordinator)
-        func contentCoordinator(
-            _ coordinator: ContentCoordinator,
-            didShowRoot runtimeObject: RuntimeObject
-        )
-        func contentCoordinator(
-            _ coordinator: ContentCoordinator,
-            didShowNext runtimeObject: RuntimeObject
-        )
-        func contentCoordinatorDidGoBack(_ coordinator: ContentCoordinator)
-    }
-
-    weak var delegate: Delegate?
-
     let documentState: DocumentState
+
+    private let disposeBag = DisposeBag()
 
     init(documentState: DocumentState) {
         self.documentState = documentState
         super.init(rootViewController: .init(nibName: nil, bundle: nil), initialRoute: nil)
+
+        documentState.$selectionStack
+            .asObservable()
+            .scan((previous: nil as [RuntimeObject]?, current: documentState.selectionStack)) { state, next in
+                (previous: state.current, current: next)
+            }
+            .subscribeOnNext { [weak self] state in
+                guard let self else { return }
+                applyStackChange(previous: state.previous, current: state.current)
+            }
+            .disposed(by: disposeBag)
     }
 
     override func prepareTransition(for route: ContentRoute) -> ContentTransition {
@@ -38,33 +36,56 @@ final class ContentCoordinator: ViewCoordinator<ContentRoute, ContentTransition>
             contentPlaceholderViewController.loadViewIfNeeded()
             return .set([contentPlaceholderViewController], animated: true)
         case .root(let runtimeObject):
-            let contentTextViewController = ContentTextViewController()
-            let contentTextViewModel = ContentTextViewModel(runtimeObject: runtimeObject, documentState: documentState, router: self)
-            contentTextViewController.setupBindings(for: contentTextViewModel)
-            contentTextViewController.loadViewIfNeeded()
-            return .set([contentTextViewController], animated: true)
+            return .set([makeTextViewController(for: runtimeObject)], animated: true)
         case .next(let runtimeObject):
-            let contentTextViewController = ContentTextViewController()
-            let contentTextViewModel = ContentTextViewModel(runtimeObject: runtimeObject, documentState: documentState, router: self)
-            contentTextViewController.setupBindings(for: contentTextViewModel)
-            contentTextViewController.loadViewIfNeeded()
-            return .push(contentTextViewController, animated: true)
+            return .push(makeTextViewController(for: runtimeObject), animated: true)
         case .back:
             return .pop(animated: true)
         }
     }
 
-    override func completeTransition(for route: ContentRoute) {
-        super.completeTransition(for: route)
-        switch route {
-        case .placeholder:
-            delegate?.contentCoordinatorDidShowPlaceholder(self)
-        case .root(let runtimeObject):
-            delegate?.contentCoordinator(self, didShowRoot: runtimeObject)
-        case .next(let runtimeObject):
-            delegate?.contentCoordinator(self, didShowNext: runtimeObject)
-        case .back:
-            delegate?.contentCoordinatorDidGoBack(self)
+    private func makeTextViewController(for runtimeObject: RuntimeObject) -> ContentTextViewController {
+        let viewController = ContentTextViewController()
+        let viewModel = ContentTextViewModel(runtimeObject: runtimeObject, documentState: documentState, router: self)
+        viewController.setupBindings(for: viewModel)
+        viewController.loadViewIfNeeded()
+        return viewController
+    }
+
+    private func applyStackChange(previous: [RuntimeObject]?, current: [RuntimeObject]) {
+        guard let previous else {
+            installStack(current)
+            return
+        }
+        if previous == current { return }
+
+        if current.isEmpty {
+            trigger(.placeholder)
+            return
+        }
+        if previous.isEmpty {
+            installStack(current)
+            return
+        }
+        if current.count == previous.count + 1, Array(current.prefix(previous.count)) == previous {
+            trigger(.next(current.last!))
+            return
+        }
+        if previous.count == current.count + 1, Array(previous.prefix(current.count)) == current {
+            trigger(.back)
+            return
+        }
+        installStack(current)
+    }
+
+    private func installStack(_ stack: [RuntimeObject]) {
+        if stack.isEmpty {
+            trigger(.placeholder)
+            return
+        }
+        trigger(.root(stack[0]))
+        for runtimeObject in stack.dropFirst() {
+            trigger(.next(runtimeObject))
         }
     }
 }

--- a/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit/Inspector/InspectorCoordinator.swift
+++ b/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit/Inspector/InspectorCoordinator.swift
@@ -7,14 +7,13 @@ import RuntimeViewerApplication
 typealias InspectorTransition = Transition<Void, InspectorNavigationController>
 
 final class InspectorCoordinator: ViewCoordinator<InspectorRoute, InspectorTransition> {
+    /// Only request that genuinely escapes Inspector scope (opens a sheet owned by
+    /// MainCoordinator). All other inter-pane synchronization flows through
+    /// `documentState.selectionStack`.
     protocol Delegate: AnyObject {
         func inspectorCoordinator(
             _ coordinator: InspectorCoordinator,
             requestSpecializationSheetFor object: RuntimeObject
-        )
-        func inspectorCoordinator(
-            _ coordinator: InspectorCoordinator,
-            selectRuntimeObject object: RuntimeObject
         )
     }
 
@@ -22,35 +21,89 @@ final class InspectorCoordinator: ViewCoordinator<InspectorRoute, InspectorTrans
 
     let documentState: DocumentState
 
-    private var runtimeObjectCoordinators: [InspectorRuntimeObjectCoordinator] = []
+    private let disposeBag = DisposeBag()
+
+    private var runtimeObjectCoordinators: [InspectorRuntimeObjectCoordinator?] = []
 
     init(documentState: DocumentState) {
         self.documentState = documentState
         super.init(rootViewController: .init(nibName: nil, bundle: nil), initialRoute: nil)
+
+        documentState.$selectionStack
+            .asObservable()
+            .scan((previous: nil as [RuntimeObject]?, current: documentState.selectionStack)) { state, next in
+                (previous: state.current, current: next)
+            }
+            .subscribeOnNext { [weak self] state in
+                guard let self else { return }
+                applyStackChange(previous: state.previous, current: state.current)
+            }
+            .disposed(by: disposeBag)
     }
 
     override func prepareTransition(for route: InspectorRoute) -> InspectorTransition {
         switch route {
         case .placeholder:
-            resetRuntimeObjectStack()
             return .set([makePlaceholder()], animated: true)
         case .root(let inspectableObject):
-            resetRuntimeObjectStack()
             return .set([makePresentable(for: inspectableObject)], animated: true)
         case .next(let inspectableObject):
             return .push(makePresentable(for: inspectableObject), animated: true)
         case .back:
-            runtimeObjectCoordinators.popLast()?.removeFromParent()
             return .pop(animated: true)
+        }
+    }
+
+    private func applyStackChange(previous: [RuntimeObject]?, current: [RuntimeObject]) {
+        guard let previous else {
+            installStack(current)
+            return
+        }
+        if previous == current { return }
+
+        if current.isEmpty {
+            resetRuntimeObjectStack()
+            trigger(.placeholder)
+            return
+        }
+        if previous.isEmpty {
+            installStack(current)
+            return
+        }
+        if current.count == previous.count + 1, Array(current.prefix(previous.count)) == previous {
+            trigger(.next(.object(current.last!)))
+            return
+        }
+        if previous.count == current.count + 1, Array(previous.prefix(current.count)) == current {
+            if let popped = runtimeObjectCoordinators.popLast() {
+                popped?.removeFromParent()
+            }
+            trigger(.back)
+            return
+        }
+        installStack(current)
+    }
+
+    private func installStack(_ stack: [RuntimeObject]) {
+        resetRuntimeObjectStack()
+        if stack.isEmpty {
+            trigger(.placeholder)
+            return
+        }
+        trigger(.root(.object(stack[0])))
+        for runtimeObject in stack.dropFirst() {
+            trigger(.next(.object(runtimeObject)))
         }
     }
 
     private func makePresentable(for inspectableObject: InspectableObject) -> Presentable {
         switch inspectableObject {
         case .node:
+            runtimeObjectCoordinators.append(nil)
             return makePlaceholder()
         case .object(let runtimeObject):
             guard InspectorRuntimeObjectCoordinator.canInspect(runtimeObject) else {
+                runtimeObjectCoordinators.append(nil)
                 return makePlaceholder()
             }
             let runtimeObjectCoordinator = InspectorRuntimeObjectCoordinator(
@@ -64,7 +117,9 @@ final class InspectorCoordinator: ViewCoordinator<InspectorRoute, InspectorTrans
     }
 
     private func resetRuntimeObjectStack() {
-        runtimeObjectCoordinators.forEach { $0.removeFromParent() }
+        for runtimeObjectCoordinator in runtimeObjectCoordinators {
+            runtimeObjectCoordinator?.removeFromParent()
+        }
         runtimeObjectCoordinators.removeAll()
     }
 
@@ -82,13 +137,5 @@ extension InspectorCoordinator: InspectorRuntimeObjectCoordinator.Delegate {
         didRequestSpecializationSheetFor object: RuntimeObject
     ) {
         delegate?.inspectorCoordinator(self, requestSpecializationSheetFor: object)
-    }
-
-    func inspectorRuntimeObjectCoordinator(
-        _ coordinator: InspectorRuntimeObjectCoordinator,
-        didSelectRuntimeObject object: RuntimeObject
-    ) {
-        delegate?.inspectorCoordinator(self, selectRuntimeObject: object)
-        trigger(.next(.object(object)))
     }
 }

--- a/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit/Inspector/InspectorCoordinator.swift
+++ b/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit/Inspector/InspectorCoordinator.swift
@@ -7,9 +7,9 @@ import RuntimeViewerApplication
 typealias InspectorTransition = Transition<Void, InspectorNavigationController>
 
 final class InspectorCoordinator: ViewCoordinator<InspectorRoute, InspectorTransition> {
-    /// Only request that genuinely escapes Inspector scope (opens a sheet owned by
-    /// MainCoordinator). All other inter-pane synchronization flows through
-    /// `documentState.selectionStack`.
+    /// Only request that genuinely escapes Inspector scope (opens a sheet
+    /// owned by MainCoordinator). All other inter-pane navigation flows
+    /// through `documentState.selectionRouter`.
     protocol Delegate: AnyObject {
         func inspectorCoordinator(
             _ coordinator: InspectorCoordinator,
@@ -21,78 +21,32 @@ final class InspectorCoordinator: ViewCoordinator<InspectorRoute, InspectorTrans
 
     let documentState: DocumentState
 
-    private let disposeBag = DisposeBag()
-
+    /// Parallel array to the inspector navigation stack. `nil` entries
+    /// correspond to placeholder pages (non-inspectable rows). Maintained
+    /// directly by `prepareTransition` — there is no longer a separate
+    /// selection-state subscription doing diff inference.
     private var runtimeObjectCoordinators: [InspectorRuntimeObjectCoordinator?] = []
 
     init(documentState: DocumentState) {
         self.documentState = documentState
         super.init(rootViewController: .init(nibName: nil, bundle: nil), initialRoute: nil)
-
-        documentState.$selectionStack
-            .asObservable()
-            .scan((previous: nil as [RuntimeObject]?, current: documentState.selectionStack)) { state, next in
-                (previous: state.current, current: next)
-            }
-            .subscribeOnNext { [weak self] state in
-                guard let self else { return }
-                applyStackChange(previous: state.previous, current: state.current)
-            }
-            .disposed(by: disposeBag)
     }
 
     override func prepareTransition(for route: InspectorRoute) -> InspectorTransition {
         switch route {
         case .placeholder:
+            resetRuntimeObjectStack()
             return .set([makePlaceholder()], animated: true)
         case .root(let inspectableObject):
+            resetRuntimeObjectStack()
             return .set([makePresentable(for: inspectableObject)], animated: true)
         case .next(let inspectableObject):
             return .push(makePresentable(for: inspectableObject), animated: true)
         case .back:
-            return .pop(animated: true)
-        }
-    }
-
-    private func applyStackChange(previous: [RuntimeObject]?, current: [RuntimeObject]) {
-        guard let previous else {
-            installStack(current)
-            return
-        }
-        if previous == current { return }
-
-        if current.isEmpty {
-            resetRuntimeObjectStack()
-            trigger(.placeholder)
-            return
-        }
-        if previous.isEmpty {
-            installStack(current)
-            return
-        }
-        if current.count == previous.count + 1, Array(current.prefix(previous.count)) == previous {
-            trigger(.next(.object(current.last!)))
-            return
-        }
-        if previous.count == current.count + 1, Array(previous.prefix(current.count)) == current {
             if let popped = runtimeObjectCoordinators.popLast() {
                 popped?.removeFromParent()
             }
-            trigger(.back)
-            return
-        }
-        installStack(current)
-    }
-
-    private func installStack(_ stack: [RuntimeObject]) {
-        resetRuntimeObjectStack()
-        if stack.isEmpty {
-            trigger(.placeholder)
-            return
-        }
-        trigger(.root(.object(stack[0])))
-        for runtimeObject in stack.dropFirst() {
-            trigger(.next(.object(runtimeObject)))
+            return .pop(animated: true)
         }
     }
 

--- a/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit/Inspector/InspectorRuntimeObjectCoordinator.swift
+++ b/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit/Inspector/InspectorRuntimeObjectCoordinator.swift
@@ -12,10 +12,6 @@ final class InspectorRuntimeObjectCoordinator: ViewCoordinator<InspectorRuntimeO
             _ coordinator: InspectorRuntimeObjectCoordinator,
             didRequestSpecializationSheetFor object: RuntimeObject
         )
-        func inspectorRuntimeObjectCoordinator(
-            _ coordinator: InspectorRuntimeObjectCoordinator,
-            didSelectRuntimeObject object: RuntimeObject
-        )
     }
 
     weak var delegate: Delegate?
@@ -48,9 +44,6 @@ final class InspectorRuntimeObjectCoordinator: ViewCoordinator<InspectorRuntimeO
             return .select(index: index)
         case .requestSpecializationSheet(let object):
             delegate?.inspectorRuntimeObjectCoordinator(self, didRequestSpecializationSheetFor: object)
-            return .none()
-        case .selectRuntimeObject(let object):
-            delegate?.inspectorRuntimeObjectCoordinator(self, didSelectRuntimeObject: object)
             return .none()
         }
     }

--- a/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit/Main/MainCoordinator.swift
+++ b/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit/Main/MainCoordinator.swift
@@ -143,7 +143,10 @@ final class MainCoordinator: SceneCoordinator<MainRoute, MainTransition>, LateRe
         case .selectAtRoot(let object):
             contentCoordinator.contextTrigger(.root(object))
             inspectorCoordinator.contextTrigger(.root(.object(object)))
-            sidebarCoordinator.programmaticallySelect(object)
+            // Sidebar visual sync is handled inside
+            // `SidebarRuntimeObjectListViewModel` by observing
+            // `documentState.$selectionStack` directly — no coordinator
+            // routing is needed for a pure UI scroll-and-highlight.
         case .drillInto(let object):
             contentCoordinator.contextTrigger(.next(object))
             inspectorCoordinator.contextTrigger(.next(.object(object)))

--- a/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit/Main/MainCoordinator.swift
+++ b/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit/Main/MainCoordinator.swift
@@ -21,6 +21,14 @@ final class MainCoordinator: SceneCoordinator<MainRoute, MainTransition>, LateRe
 
     private(set) lazy var lateResponderRegistry = LateResponderRegistry()
 
+    /// Subscription to `documentState.routeSignal`. Renewed on every
+    /// engine switch (`.main` case) because the fan-out captures the
+    /// currently-installed sub-coordinators by reference; tearing down the
+    /// old subscription before the silent state reset prevents stale
+    /// `.placeholder` / `.back` transitions from being queued on
+    /// soon-to-be-discarded coordinators.
+    private var routeDisposeBag = DisposeBag()
+
     init(documentState: DocumentState) {
         self.documentState = documentState
         super.init(windowController: .init(documentState: documentState), initialRoute: .main(.local))
@@ -29,8 +37,12 @@ final class MainCoordinator: SceneCoordinator<MainRoute, MainTransition>, LateRe
     override func prepareTransition(for route: MainRoute) -> MainTransition {
         switch route {
         case .main(let runtimeEngine):
-            documentState.runtimeEngine = runtimeEngine
-            documentState.currentImageNode = nil
+            // Drop the previous subscription FIRST so the upcoming
+            // `.switchEngine` reset emits with no listener, leaving the
+            // dying sub-coordinators untouched.
+            routeDisposeBag = DisposeBag()
+            documentState.selectionRouter.trigger(.switchEngine(runtimeEngine))
+
             sidebarCoordinator.removeFromParent()
             contentCoordinator.removeFromParent()
             inspectorCoordinator.removeFromParent()
@@ -39,10 +51,18 @@ final class MainCoordinator: SceneCoordinator<MainRoute, MainTransition>, LateRe
             inspectorCoordinator = InspectorCoordinator(documentState: documentState)
             inspectorCoordinator.delegate = self
             windowController.setupBindings(for: viewModel)
+
+            // Subscribe with the fresh sub-coordinators in place.
+            documentState.routeSignal
+                .emit(with: self) { $0.fanOut($1) }
+                .disposed(by: routeDisposeBag)
+
             return .multiple(
                 .show(windowController.splitViewController),
                 .set(sidebar: sidebarCoordinator, content: contentCoordinator, inspector: inspectorCoordinator),
-                .route(on: sidebarCoordinator, to: .root)
+                .route(on: sidebarCoordinator, to: .root),
+                .route(on: contentCoordinator, to: .placeholder),
+                .route(on: inspectorCoordinator, to: .placeholder),
             )
         case .generationOptions(let sender):
             let viewController = GenerationOptionsViewController()
@@ -104,15 +124,58 @@ final class MainCoordinator: SceneCoordinator<MainRoute, MainTransition>, LateRe
         }
     }
 
+    // MARK: - Route fan-out
+    //
+    // Receives each `SelectionRoute` after `DocumentState` has applied its
+    // state mutation, and translates it into typed routes on the three
+    // sub-coordinators. This is the only place that knows how a route
+    // affects each pane.
+
+    private func fanOut(_ route: SelectionRoute) {
+        switch route {
+        case .switchEngine:
+            // `.switchEngine` is exclusively triggered from the `.main`
+            // route handler above, which tears down the subscription
+            // before triggering. Reaching this branch means a contract
+            // violation — log once, take no action (the handler is the
+            // only path that can correctly rebuild the sub-coordinators).
+            assertionFailure(".switchEngine fired with an active route subscriber; engine switches must go through MainRoute.main")
+        case .selectAtRoot(let object):
+            contentCoordinator.contextTrigger(.root(object))
+            inspectorCoordinator.contextTrigger(.root(.object(object)))
+            sidebarCoordinator.programmaticallySelect(object)
+        case .drillInto(let object):
+            contentCoordinator.contextTrigger(.next(object))
+            inspectorCoordinator.contextTrigger(.next(.object(object)))
+        case .pop:
+            if documentState.selectionStack.isEmpty {
+                contentCoordinator.contextTrigger(.placeholder)
+                inspectorCoordinator.contextTrigger(.placeholder)
+            } else {
+                contentCoordinator.contextTrigger(.back)
+                inspectorCoordinator.contextTrigger(.back)
+            }
+        case .clear:
+            contentCoordinator.contextTrigger(.placeholder)
+            inspectorCoordinator.contextTrigger(.placeholder)
+        case .switchImage(let node):
+            contentCoordinator.contextTrigger(.placeholder)
+            inspectorCoordinator.contextTrigger(.placeholder)
+            if let node {
+                sidebarCoordinator.contextTrigger(.clickedNode(node))
+            } else {
+                sidebarCoordinator.contextTrigger(.back)
+            }
+        }
+    }
 }
 
 // MARK: - Cross-scope sheet requests
 //
 // These two delegates exist because both events open a sheet that is owned
 // by `MainCoordinator` (not by the originating sub-coordinator) — that's a
-// scope crossing `documentState` cannot model. Pure state-driven UI updates
-// (sidebar, content, inspector navigation) live entirely in `documentState`
-// subscriptions inside each sub-coordinator and do not need delegates.
+// scope crossing the selection route vocabulary intentionally does not
+// model. All cross-pane navigation flows through `documentState.selectionRouter`.
 
 extension MainCoordinator: InspectorCoordinator.Delegate {
     func inspectorCoordinator(
@@ -128,6 +191,6 @@ extension MainCoordinator: SpecializationCoordinator.Delegate {
         _: SpecializationCoordinator,
         didProduce specialized: RuntimeObject
     ) {
-        documentState.selectionStack = [specialized]
+        documentState.selectionRouter.trigger(.selectAtRoot(specialized))
     }
 }

--- a/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit/Main/MainCoordinator.swift
+++ b/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit/Main/MainCoordinator.swift
@@ -35,27 +35,15 @@ final class MainCoordinator: SceneCoordinator<MainRoute, MainTransition>, LateRe
             contentCoordinator.removeFromParent()
             inspectorCoordinator.removeFromParent()
             sidebarCoordinator = SidebarCoordinator(documentState: documentState)
-            sidebarCoordinator.delegate = self
             contentCoordinator = ContentCoordinator(documentState: documentState)
-            contentCoordinator.delegate = self
             inspectorCoordinator = InspectorCoordinator(documentState: documentState)
             inspectorCoordinator.delegate = self
-            viewModel.completeTransition = sidebarCoordinator.rx.didCompleteTransition()
             windowController.setupBindings(for: viewModel)
             return .multiple(
                 .show(windowController.splitViewController),
                 .set(sidebar: sidebarCoordinator, content: contentCoordinator, inspector: inspectorCoordinator),
-                .route(on: sidebarCoordinator, to: .root),
-                .route(on: contentCoordinator, to: .placeholder),
-                .route(on: inspectorCoordinator, to: .placeholder)
+                .route(on: sidebarCoordinator, to: .root)
             )
-        case .select(let runtimeObject):
-            sidebarCoordinator.programmaticallySelectObject(runtimeObject)
-            return .none()
-        case .sidebarBack:
-            return .route(on: sidebarCoordinator, to: .back)
-        case .contentBack:
-            return .route(on: contentCoordinator, to: .back)
         case .generationOptions(let sender):
             let viewController = GenerationOptionsViewController()
             let viewModel = GenerationOptionsViewModel(documentState: documentState, router: self)
@@ -75,8 +63,6 @@ final class MainCoordinator: SceneCoordinator<MainRoute, MainTransition>, LateRe
             )
             viewController.setupBindings(for: viewModel)
             return .presentOnRoot(viewController, mode: .asPopover(relativeToRect: sender.bounds, ofView: sender, preferredEdge: .maxY, behavior: .transient))
-        case .loadFramework:
-            return .none()
         case .attachToProcess:
             let viewController = AttachToProcessViewController()
             let viewModel = AttachToProcessViewModel(documentState: documentState, router: self)
@@ -118,67 +104,15 @@ final class MainCoordinator: SceneCoordinator<MainRoute, MainTransition>, LateRe
         }
     }
 
-    private func updateContentStackDepth() {
-        let hasBackStack = contentCoordinator.rootViewController.viewControllers.count >= 2
-        viewModel.isContentStackDepthGreaterThanOne.accept(hasBackStack)
-    }
 }
 
-// MARK: - Sidebar / Content / Inspector / Specialization delegate plumbing
-
-extension MainCoordinator: SidebarCoordinator.Delegate {
-    func sidebarCoordinator(
-        _ coordinator: SidebarCoordinator,
-        didSelectObject runtimeObject: RuntimeObject
-    ) {
-        documentState.selectedRuntimeObject = runtimeObject
-        contentCoordinator.trigger(.root(runtimeObject))
-    }
-
-    func sidebarCoordinator(
-        _ coordinator: SidebarCoordinator,
-        didClickImageNode imageNode: RuntimeImageNode
-    ) {
-        documentState.currentImageNode = imageNode
-    }
-
-    func sidebarCoordinatorDidGoBack(_ coordinator: SidebarCoordinator) {
-        documentState.currentImageNode = nil
-        documentState.selectedRuntimeObject = nil
-        contentCoordinator.trigger(.placeholder)
-    }
-}
-
-extension MainCoordinator: ContentCoordinator.Delegate {
-    func contentCoordinatorDidShowPlaceholder(_ coordinator: ContentCoordinator) {
-        updateContentStackDepth()
-        documentState.selectedRuntimeObject = nil
-        inspectorCoordinator.trigger(.placeholder)
-    }
-
-    func contentCoordinator(
-        _ coordinator: ContentCoordinator,
-        didShowRoot runtimeObject: RuntimeObject
-    ) {
-        updateContentStackDepth()
-        documentState.selectedRuntimeObject = runtimeObject
-        inspectorCoordinator.trigger(.root(.object(runtimeObject)))
-    }
-
-    func contentCoordinator(
-        _ coordinator: ContentCoordinator,
-        didShowNext runtimeObject: RuntimeObject
-    ) {
-        updateContentStackDepth()
-        documentState.selectedRuntimeObject = runtimeObject
-        inspectorCoordinator.trigger(.next(.object(runtimeObject)))
-    }
-
-    func contentCoordinatorDidGoBack(_ coordinator: ContentCoordinator) {
-        updateContentStackDepth()
-        inspectorCoordinator.trigger(.back)
-    }
-}
+// MARK: - Cross-scope sheet requests
+//
+// These two delegates exist because both events open a sheet that is owned
+// by `MainCoordinator` (not by the originating sub-coordinator) — that's a
+// scope crossing `documentState` cannot model. Pure state-driven UI updates
+// (sidebar, content, inspector navigation) live entirely in `documentState`
+// subscriptions inside each sub-coordinator and do not need delegates.
 
 extension MainCoordinator: InspectorCoordinator.Delegate {
     func inspectorCoordinator(
@@ -187,13 +121,6 @@ extension MainCoordinator: InspectorCoordinator.Delegate {
     ) {
         contextTrigger(.beginSpecializationSheet(object))
     }
-
-    func inspectorCoordinator(
-        _: InspectorCoordinator,
-        selectRuntimeObject object: RuntimeObject
-    ) {
-        contentCoordinator.trigger(.next(object))
-    }
 }
 
 extension MainCoordinator: SpecializationCoordinator.Delegate {
@@ -201,6 +128,6 @@ extension MainCoordinator: SpecializationCoordinator.Delegate {
         _: SpecializationCoordinator,
         didProduce specialized: RuntimeObject
     ) {
-        contextTrigger(.select(specialized))
+        documentState.selectionStack = [specialized]
     }
 }

--- a/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit/Main/MainRoute.swift
+++ b/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit/Main/MainRoute.swift
@@ -9,11 +9,7 @@ import RuntimeViewerApplication
 @CaseCheckable(.public)
 public enum MainRoute: Routable {
     case main(RuntimeEngine)
-    case select(RuntimeObject)
-    case sidebarBack
-    case contentBack
     case generationOptions(sender: NSView)
-    case loadFramework
     case attachToProcess
     case mcpStatus(sender: NSView)
     case backgroundIndexing(sender: NSView)

--- a/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit/Main/MainViewModel.swift
+++ b/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit/Main/MainViewModel.swift
@@ -113,7 +113,7 @@ final class MainViewModel: ViewModel<MainRoute> {
             }
         }.disposed(by: rx.disposeBag)
 
-        
+
 
 //        input.installHelperClick.emitOnNext { [weak self] in
 //            guard let self else { return }
@@ -152,16 +152,13 @@ final class MainViewModel: ViewModel<MainRoute> {
 
         input.sidebarBackClick.emitOnNext { [weak self] in
             guard let self else { return }
-            documentState.currentImageNode = nil
-            documentState.selectionStack = []
+            documentState.selectionRouter.trigger(.switchImage(nil))
         }
         .disposed(by: rx.disposeBag)
 
         input.contentBackClick.emitOnNext { [weak self] in
             guard let self else { return }
-            if !documentState.selectionStack.isEmpty {
-                documentState.selectionStack.removeLast()
-            }
+            documentState.selectionRouter.trigger(.pop)
         }
         .disposed(by: rx.disposeBag)
 

--- a/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit/Main/MainViewModel.swift
+++ b/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit/Main/MainViewModel.swift
@@ -68,17 +68,6 @@ final class MainViewModel: ViewModel<MainRoute> {
 
     @Dependency(\.runtimeEngineManager) private var runtimeEngineManager
 
-    var completeTransition: Observable<SidebarRoute>? {
-        didSet {
-            completeTransitionDisposable?.dispose()
-            completeTransitionDisposable = completeTransition?.map { if case .selectedObject(let runtimeObject) = $0 { runtimeObject } else { nil } }.bind(to: $selectedRuntimeObject)
-        }
-    }
-
-    var completeTransitionDisposable: Disposable?
-
-    let isContentStackDepthGreaterThanOne = BehaviorRelay<Bool>(value: false)
-
     @Observed private(set) var selectedEngineIdentifier: String = RuntimeEngine.local.engineID
 
     private var cachedSelectedEngineName: String = RuntimeEngine.local.source.description
@@ -102,9 +91,6 @@ final class MainViewModel: ViewModel<MainRoute> {
             }
         }
     }
-
-    @Observed
-    var selectedRuntimeObject: RuntimeObject?
 
     private let requestRestartConfirmationRelay = PublishRelay<Void>()
 
@@ -164,9 +150,20 @@ final class MainViewModel: ViewModel<MainRoute> {
         }
         .disposed(by: rx.disposeBag)
 
-        input.sidebarBackClick.emit(to: router.rx.trigger(.sidebarBack)).disposed(by: rx.disposeBag)
+        input.sidebarBackClick.emitOnNext { [weak self] in
+            guard let self else { return }
+            documentState.currentImageNode = nil
+            documentState.selectionStack = []
+        }
+        .disposed(by: rx.disposeBag)
 
-        input.contentBackClick.emit(to: router.rx.trigger(.contentBack)).disposed(by: rx.disposeBag)
+        input.contentBackClick.emitOnNext { [weak self] in
+            guard let self else { return }
+            if !documentState.selectionStack.isEmpty {
+                documentState.selectionStack.removeLast()
+            }
+        }
+        .disposed(by: rx.disposeBag)
 
         input.generationOptionsClick.emit(with: self) { $0.router.trigger(.generationOptions(sender: $1)) }.disposed(by: rx.disposeBag)
 
@@ -174,13 +171,17 @@ final class MainViewModel: ViewModel<MainRoute> {
 
         input.backgroundIndexingClick.emit(with: self) { $0.router.trigger(.backgroundIndexing(sender: $1)) }.disposed(by: rx.disposeBag)
 
+        let selectedRuntimeObjectSignal = documentState.$selectionStack
+            .asSignal(onErrorSignalWith: .empty())
+            .map(\.last)
+
         let requestSaveLocation = input.saveClick
-            .withLatestFrom($selectedRuntimeObject.asSignalOnErrorJustComplete())
+            .withLatestFrom(selectedRuntimeObjectSignal)
             .filterNil()
             .map { (name: $0.displayName, type: $0.contentType) }
 
         input.saveLocationSelected
-            .withLatestFrom($selectedRuntimeObject.asSignalOnErrorJustComplete()) { saveLocation, selectedRuntimeObject in
+            .withLatestFrom(selectedRuntimeObjectSignal) { saveLocation, selectedRuntimeObject in
                 selectedRuntimeObject.map { (saveLocation, $0) }
             }
             .filterNil()
@@ -206,30 +207,32 @@ final class MainViewModel: ViewModel<MainRoute> {
             owner.selectedEngineIdentifier = identifier
         }.disposed(by: rx.disposeBag)
 
-        let sharingServiceData = completeTransition?.map { [weak self] router -> [SharingData] in
-            guard let self, case .selectedObject(let runtimeObjectType) = router else { return [] }
-            
-            let item = NSItemProvider()
-            
-            item.registerDataRepresentation(forTypeIdentifier: runtimeObjectType.contentType.identifier, visibility: .all) { [weak self] completion in
-                guard let self else {
-                    completion(nil, nil)
+        let sharingServiceData = documentState.$selectionStack
+            .asObservable()
+            .map { [weak self] stack -> [SharingData] in
+                guard let self, let runtimeObjectType = stack.last else { return [] }
+
+                let item = NSItemProvider()
+
+                item.registerDataRepresentation(forTypeIdentifier: runtimeObjectType.contentType.identifier, visibility: .all) { [weak self] completion in
+                    guard let self else {
+                        completion(nil, nil)
+                        return nil
+                    }
+                    Task { [weak self] in
+                        guard let self else { return }
+                        do {
+                            let semanticString = try await documentState.runtimeEngine.interface(for: runtimeObjectType, options: self.appDefaults.options)?.interfaceString
+                            completion(semanticString?.string.data(using: .utf8), nil)
+                        } catch {
+                            completion(nil, error)
+                        }
+                    }
                     return nil
                 }
-                Task { [weak self] in
-                    guard let self else { return }
-                    do {
-                        let semanticString = try await documentState.runtimeEngine.interface(for: runtimeObjectType, options: self.appDefaults.options)?.interfaceString
-                        completion(semanticString?.string.data(using: .utf8), nil)
-                    } catch {
-                        completion(nil, error)
-                    }
-                }
-                return nil
+
+                return [SharingData(provider: item, title: runtimeObjectType.displayName, iconType: runtimeObjectType.kind)]
             }
-            
-            return [SharingData(provider: item, title: runtimeObjectType.displayName, iconType: runtimeObjectType.kind)]
-        }
 
         let switchSourceState = Driver.combineLatest(
             runtimeEngineManager.rx.runtimeEngineSections,
@@ -261,18 +264,10 @@ final class MainViewModel: ViewModel<MainRoute> {
         }
 
         return Output(
-            sharingServiceData: sharingServiceData ?? .empty(),
-            isSavable: $selectedRuntimeObject.asDriver().map { $0 != nil },
-            isSidebarBackHidden: completeTransition?.map {
-                if $0.isClickedNode || $0.isSelectedObject {
-                    false
-                } else {
-                    true
-                }
-            }.asDriver(onErrorJustReturn: true) ?? .just(true),
-            isContentBackHidden: isContentStackDepthGreaterThanOne.map {
-                !$0
-            }.asDriver(onErrorJustReturn: true),
+            sharingServiceData: sharingServiceData,
+            isSavable: documentState.$selectionStack.asDriver().map { !$0.isEmpty },
+            isSidebarBackHidden: documentState.$currentImageNode.asDriver().map { $0 == nil },
+            isContentBackHidden: documentState.$selectionStack.asDriver().map { $0.count <= 1 },
             runtimeEngineSections: runtimeEngineManager.rx.runtimeEngineSections,
             switchSourceState: switchSourceState,
             requestFrameworkSelection: requestFrameworkSelection,

--- a/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit/Sidebar/Root/SidebarRootCoordinator.swift
+++ b/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit/Sidebar/Root/SidebarRootCoordinator.swift
@@ -7,15 +7,6 @@ import RuntimeViewerArchitectures
 typealias SidebarRootTransition = Transition<Void, SidebarRootTabViewController>
 
 final class SidebarRootCoordinator: ViewCoordinator<SidebarRootRoute, SidebarRootTransition> {
-    protocol Delegate: AnyObject {
-        func rootCoordinator(
-            _ coordinator: SidebarRootCoordinator,
-            didClickImageNode imageNode: RuntimeImageNode
-        )
-    }
-
-    weak var delegate: Delegate?
-
     let documentState: DocumentState
 
     init(documentState: DocumentState) {
@@ -41,9 +32,6 @@ final class SidebarRootCoordinator: ViewCoordinator<SidebarRootRoute, SidebarRoo
             return .select(index: 0)
         case .bookmarks:
             return .select(index: 1)
-        case .image(let imageNode):
-            delegate?.rootCoordinator(self, didClickImageNode: imageNode)
-            return .none()
         }
     }
 }

--- a/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit/Sidebar/RuntimeObject/SidebarRuntimeObjectCoordinator.swift
+++ b/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit/Sidebar/RuntimeObject/SidebarRuntimeObjectCoordinator.swift
@@ -11,22 +11,10 @@ final class SidebarRuntimeObjectCoordinator: ViewCoordinator<SidebarRuntimeObjec
 
     let imageNode: RuntimeImageNode
 
-    private weak var listViewModel: SidebarRuntimeObjectListViewModel?
-
     init(documentState: DocumentState, imageNode: RuntimeImageNode) {
         self.documentState = documentState
         self.imageNode = imageNode
         super.init(rootViewController: .init(), initialRoute: .initial)
-    }
-
-    /// Drives the visual selection in the underlying list — independent of
-    /// `DocumentState.selectionStack`, which is the data-level source of
-    /// truth. Called by `SidebarCoordinator.programmaticallySelect(_:)`
-    /// during the `.selectAtRoot` intent fan-out (sidebar row click is
-    /// idempotent; specialization completion uses it to scroll-to-and-
-    /// highlight the newly produced object).
-    func programmaticallySelect(_ object: RuntimeObject) {
-        listViewModel?.selectRuntimeObject(object)
     }
 
     override func prepareTransition(for route: SidebarRuntimeObjectRoute) -> SidebarRuntimeObjectTransition {
@@ -35,7 +23,6 @@ final class SidebarRuntimeObjectCoordinator: ViewCoordinator<SidebarRuntimeObjec
             let listViewController = SidebarRuntimeObjectListViewController()
             let listViewModel = SidebarRuntimeObjectListViewModel(imageNode: imageNode, documentState: documentState, router: self)
             listViewController.setupBindings(for: listViewModel)
-            self.listViewModel = listViewModel
 
             let bookmarkViewController = SidebarRuntimeObjectBookmarkViewController()
             let bookmarkViewModel = SidebarRuntimeObjectBookmarkViewModel(imageNode: imageNode, documentState: documentState, router: self)

--- a/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit/Sidebar/RuntimeObject/SidebarRuntimeObjectCoordinator.swift
+++ b/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit/Sidebar/RuntimeObject/SidebarRuntimeObjectCoordinator.swift
@@ -7,15 +7,6 @@ import RuntimeViewerArchitectures
 typealias SidebarRuntimeObjectTransition = Transition<Void, SidebarRuntimeObjectTabViewController>
 
 final class SidebarRuntimeObjectCoordinator: ViewCoordinator<SidebarRuntimeObjectRoute, SidebarRuntimeObjectTransition> {
-    protocol Delegate: AnyObject {
-        func runtimeObjectCoordinator(
-            _ coordinator: SidebarRuntimeObjectCoordinator,
-            didSelectObject object: RuntimeObject
-        )
-    }
-
-    weak var delegate: Delegate?
-
     let documentState: DocumentState
 
     let imageNode: RuntimeImageNode
@@ -28,8 +19,13 @@ final class SidebarRuntimeObjectCoordinator: ViewCoordinator<SidebarRuntimeObjec
         super.init(rootViewController: .init(), initialRoute: .initial)
     }
 
+    /// Drives the visual selection in the underlying list — independent of
+    /// `documentState.selectionStack`, which is the data-level source of truth.
+    /// Called by `SidebarCoordinator` whenever the root selection changes
+    /// (sidebar row click is idempotent; specialization completion uses it
+    /// to scroll-to-and-highlight the newly produced object).
     func programmaticallySelectObject(_ object: RuntimeObject) {
-        trigger(.selectedObject(object))
+        listViewModel?.selectRuntimeObject(object)
     }
 
     override func prepareTransition(for route: SidebarRuntimeObjectRoute) -> SidebarRuntimeObjectTransition {
@@ -52,11 +48,6 @@ final class SidebarRuntimeObjectCoordinator: ViewCoordinator<SidebarRuntimeObjec
             return .select(index: 0)
         case .bookmarks:
             return .select(index: 1)
-        case .selectedObject(let object):
-            listViewModel?.selectRuntimeObject(object)
-            delegate?.runtimeObjectCoordinator(self, didSelectObject: object)
-            return .none()
         }
     }
-
 }

--- a/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit/Sidebar/RuntimeObject/SidebarRuntimeObjectCoordinator.swift
+++ b/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit/Sidebar/RuntimeObject/SidebarRuntimeObjectCoordinator.swift
@@ -20,11 +20,12 @@ final class SidebarRuntimeObjectCoordinator: ViewCoordinator<SidebarRuntimeObjec
     }
 
     /// Drives the visual selection in the underlying list — independent of
-    /// `documentState.selectionStack`, which is the data-level source of truth.
-    /// Called by `SidebarCoordinator` whenever the root selection changes
-    /// (sidebar row click is idempotent; specialization completion uses it
-    /// to scroll-to-and-highlight the newly produced object).
-    func programmaticallySelectObject(_ object: RuntimeObject) {
+    /// `DocumentState.selectionStack`, which is the data-level source of
+    /// truth. Called by `SidebarCoordinator.programmaticallySelect(_:)`
+    /// during the `.selectAtRoot` intent fan-out (sidebar row click is
+    /// idempotent; specialization completion uses it to scroll-to-and-
+    /// highlight the newly produced object).
+    func programmaticallySelect(_ object: RuntimeObject) {
         listViewModel?.selectRuntimeObject(object)
     }
 

--- a/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit/Sidebar/SidebarCoordinator.swift
+++ b/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit/Sidebar/SidebarCoordinator.swift
@@ -18,16 +18,6 @@ final class SidebarCoordinator: ViewCoordinator<SidebarRoute, SidebarTransition>
         super.init(rootViewController: .init(nibName: nil, bundle: nil), initialRoute: nil)
     }
 
-    /// Drives the visual selection in the underlying runtime object list.
-    /// Idempotent if the sidebar is at the root level (no list mounted).
-    /// Called by `MainCoordinator` while fanning out a `.selectAtRoot`
-    /// intent so root selection changes originating outside the sidebar
-    /// (specialization completion, future deep-link, etc.) still
-    /// scroll-and-highlight the matching row.
-    func programmaticallySelect(_ object: RuntimeObject) {
-        runtimeObjectCoordinator?.programmaticallySelect(object)
-    }
-
     override func prepareTransition(for route: SidebarRoute) -> SidebarTransition {
         switch route {
         case .root:
@@ -48,9 +38,10 @@ final class SidebarCoordinator: ViewCoordinator<SidebarRoute, SidebarTransition>
             runtimeObjectCoordinator = nil
             return .pop(animated: true)
         case .selectedObject, .selectedNode:
-            // macOS uses `SelectionRoute.selectAtRoot` / `.switchImage`
-            // directly; the cross-platform `SidebarRoute` carries these
-            // cases for iOS only.
+            // iOS-only cases; on macOS the runtime-object list scrolls to
+            // and highlights the root selection by observing
+            // `documentState.$selectionStack` directly, and image switches
+            // flow through `SelectionRoute.switchImage`.
             return .none()
         }
     }

--- a/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit/Sidebar/SidebarCoordinator.swift
+++ b/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit/Sidebar/SidebarCoordinator.swift
@@ -9,8 +9,6 @@ typealias SidebarTransition = Transition<Void, SidebarNavigationController>
 final class SidebarCoordinator: ViewCoordinator<SidebarRoute, SidebarTransition> {
     let documentState: DocumentState
 
-    private let disposeBag = DisposeBag()
-
     private var rootCoordinator: SidebarRootCoordinator?
 
     private var runtimeObjectCoordinator: SidebarRuntimeObjectCoordinator?
@@ -18,27 +16,16 @@ final class SidebarCoordinator: ViewCoordinator<SidebarRoute, SidebarTransition>
     init(documentState: DocumentState) {
         self.documentState = documentState
         super.init(rootViewController: .init(nibName: nil, bundle: nil), initialRoute: nil)
+    }
 
-        documentState.$currentImageNode
-            .asObservable()
-            .scan((previous: nil as RuntimeImageNode??, current: documentState.currentImageNode)) { state, next in
-                (previous: state.current, current: next)
-            }
-            .subscribeOnNext { [weak self] state in
-                guard let self else { return }
-                applyImageNodeChange(previousLayer: state.previous, current: state.current)
-            }
-            .disposed(by: disposeBag)
-
-        documentState.$selectionStack
-            .asObservable()
-            .map { $0.first }
-            .distinctUntilChanged()
-            .subscribeOnNext { [weak self] rootSelection in
-                guard let self, let rootSelection else { return }
-                runtimeObjectCoordinator?.programmaticallySelectObject(rootSelection)
-            }
-            .disposed(by: disposeBag)
+    /// Drives the visual selection in the underlying runtime object list.
+    /// Idempotent if the sidebar is at the root level (no list mounted).
+    /// Called by `MainCoordinator` while fanning out a `.selectAtRoot`
+    /// intent so root selection changes originating outside the sidebar
+    /// (specialization completion, future deep-link, etc.) still
+    /// scroll-and-highlight the matching row.
+    func programmaticallySelect(_ object: RuntimeObject) {
+        runtimeObjectCoordinator?.programmaticallySelect(object)
     }
 
     override func prepareTransition(for route: SidebarRoute) -> SidebarTransition {
@@ -50,34 +37,21 @@ final class SidebarCoordinator: ViewCoordinator<SidebarRoute, SidebarTransition>
             return .set([rootCoordinator], animated: false)
         case .clickedNode(let imageNode):
             runtimeObjectCoordinator?.removeFromParent()
-            let runtimeObjectCoordinator = SidebarRuntimeObjectCoordinator(documentState: documentState, imageNode: imageNode)
+            let runtimeObjectCoordinator = SidebarRuntimeObjectCoordinator(
+                documentState: documentState,
+                imageNode: imageNode
+            )
             self.runtimeObjectCoordinator = runtimeObjectCoordinator
             return .push(runtimeObjectCoordinator, animated: true)
         case .back:
+            runtimeObjectCoordinator?.removeFromParent()
+            runtimeObjectCoordinator = nil
             return .pop(animated: true)
         case .selectedObject, .selectedNode:
-            // macOS uses `documentState.selectionStack` and `currentImageNode`
-            // directly; the cross-platform `SidebarRoute` carries these cases
-            // for iOS only.
+            // macOS uses `SelectionRoute.selectAtRoot` / `.switchImage`
+            // directly; the cross-platform `SidebarRoute` carries these
+            // cases for iOS only.
             return .none()
-        }
-    }
-
-    private func applyImageNodeChange(previousLayer: RuntimeImageNode??, current: RuntimeImageNode?) {
-        guard let previous = previousLayer else {
-            if let current {
-                trigger(.clickedNode(current))
-            }
-            return
-        }
-        if previous == current { return }
-        if previous == nil, let current {
-            trigger(.clickedNode(current))
-        } else if previous != nil, current == nil {
-            trigger(.back)
-        } else if let next = current {
-            trigger(.back)
-            trigger(.clickedNode(next))
         }
     }
 }

--- a/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit/Sidebar/SidebarCoordinator.swift
+++ b/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit/Sidebar/SidebarCoordinator.swift
@@ -7,21 +7,9 @@ import RuntimeViewerApplication
 typealias SidebarTransition = Transition<Void, SidebarNavigationController>
 
 final class SidebarCoordinator: ViewCoordinator<SidebarRoute, SidebarTransition> {
-    protocol Delegate: AnyObject {
-        func sidebarCoordinator(
-            _ coordinator: SidebarCoordinator,
-            didSelectObject object: RuntimeObject
-        )
-        func sidebarCoordinator(
-            _ coordinator: SidebarCoordinator,
-            didClickImageNode imageNode: RuntimeImageNode
-        )
-        func sidebarCoordinatorDidGoBack(_ coordinator: SidebarCoordinator)
-    }
-
-    weak var delegate: Delegate?
-
     let documentState: DocumentState
+
+    private let disposeBag = DisposeBag()
 
     private var rootCoordinator: SidebarRootCoordinator?
 
@@ -30,10 +18,27 @@ final class SidebarCoordinator: ViewCoordinator<SidebarRoute, SidebarTransition>
     init(documentState: DocumentState) {
         self.documentState = documentState
         super.init(rootViewController: .init(nibName: nil, bundle: nil), initialRoute: nil)
-    }
 
-    func programmaticallySelectObject(_ object: RuntimeObject) {
-        runtimeObjectCoordinator?.programmaticallySelectObject(object)
+        documentState.$currentImageNode
+            .asObservable()
+            .scan((previous: nil as RuntimeImageNode??, current: documentState.currentImageNode)) { state, next in
+                (previous: state.current, current: next)
+            }
+            .subscribeOnNext { [weak self] state in
+                guard let self else { return }
+                applyImageNodeChange(previousLayer: state.previous, current: state.current)
+            }
+            .disposed(by: disposeBag)
+
+        documentState.$selectionStack
+            .asObservable()
+            .map { $0.first }
+            .distinctUntilChanged()
+            .subscribeOnNext { [weak self] rootSelection in
+                guard let self, let rootSelection else { return }
+                runtimeObjectCoordinator?.programmaticallySelectObject(rootSelection)
+            }
+            .disposed(by: disposeBag)
     }
 
     override func prepareTransition(for route: SidebarRoute) -> SidebarTransition {
@@ -41,57 +46,38 @@ final class SidebarCoordinator: ViewCoordinator<SidebarRoute, SidebarTransition>
         case .root:
             rootCoordinator?.removeFromParent()
             let rootCoordinator = SidebarRootCoordinator(documentState: documentState)
-            rootCoordinator.delegate = self
             self.rootCoordinator = rootCoordinator
             return .set([rootCoordinator], animated: false)
         case .clickedNode(let imageNode):
             runtimeObjectCoordinator?.removeFromParent()
             let runtimeObjectCoordinator = SidebarRuntimeObjectCoordinator(documentState: documentState, imageNode: imageNode)
-            runtimeObjectCoordinator.delegate = self
             self.runtimeObjectCoordinator = runtimeObjectCoordinator
             return .push(runtimeObjectCoordinator, animated: true)
         case .back:
             return .pop(animated: true)
-        case .selectedObject:
-            // Programmatic selection enters via `programmaticallySelectObject(_)` which
-            // routes through the sub-coordinator directly. Forwarding here would create
-            // a feedback loop (sub-coord delegate → SidebarCoord.trigger(.selectedObject)
-            // → forward to sub-coord → delegate again …). The trigger is preserved only
-            // to keep `MainViewModel.completeTransition` (Sidebar didCompleteTransition)
-            // emitting `.selectedObject`.
-            return .none()
-        case .selectedNode:
+        case .selectedObject, .selectedNode:
+            // macOS uses `documentState.selectionStack` and `currentImageNode`
+            // directly; the cross-platform `SidebarRoute` carries these cases
+            // for iOS only.
             return .none()
         }
     }
 
-    override func completeTransition(for route: SidebarRoute) {
-        super.completeTransition(for: route)
-        switch route {
-        case .back:
-            delegate?.sidebarCoordinatorDidGoBack(self)
-        case .root, .clickedNode, .selectedObject, .selectedNode:
-            break
+    private func applyImageNodeChange(previousLayer: RuntimeImageNode??, current: RuntimeImageNode?) {
+        guard let previous = previousLayer else {
+            if let current {
+                trigger(.clickedNode(current))
+            }
+            return
         }
-    }
-}
-
-extension SidebarCoordinator: SidebarRootCoordinator.Delegate {
-    func rootCoordinator(
-        _ coordinator: SidebarRootCoordinator,
-        didClickImageNode imageNode: RuntimeImageNode
-    ) {
-        delegate?.sidebarCoordinator(self, didClickImageNode: imageNode)
-        trigger(.clickedNode(imageNode))
-    }
-}
-
-extension SidebarCoordinator: SidebarRuntimeObjectCoordinator.Delegate {
-    func runtimeObjectCoordinator(
-        _ coordinator: SidebarRuntimeObjectCoordinator,
-        didSelectObject object: RuntimeObject
-    ) {
-        delegate?.sidebarCoordinator(self, didSelectObject: object)
-        trigger(.selectedObject(object))
+        if previous == current { return }
+        if previous == nil, let current {
+            trigger(.clickedNode(current))
+        } else if previous != nil, current == nil {
+            trigger(.back)
+        } else if let next = current {
+            trigger(.back)
+            trigger(.clickedNode(next))
+        }
     }
 }


### PR DESCRIPTION
## Summary
Centralises sidebar / content / inspector navigation into a single typed router on \`DocumentState\`. Each view model now triggers a \`SelectionRoute\` (\`switchEngine\` / \`switchImage\` / \`selectAtRoot\` / \`drillInto\` / \`pop\` / \`clear\`); \`DocumentState\` applies the mutation atomically and emits on \`routeSignal\`; \`MainCoordinator\` fans out from there to the three pane coordinators.

Replaces the previous web of delegate plumbing (\`SidebarCoordinator.Delegate\`, \`ContentCoordinator.Delegate\`, large parts of \`InspectorCoordinator.Delegate\`, \`MainViewModel.completeTransition\`) — every cross-pane navigation request now flows through a single typed enum.

### What changed
- **refactor(coordinator)** `84b873f` — \`DocumentState\` gains a \`selectionStack: [RuntimeObject]\`; \`MainCoordinator\` derives its sub-coordinator routing from observing the stack instead of manually wiring delegate callbacks. Sidebar / inspector coordinators stop emitting \`.selectRuntimeObject\` / \`.selectedObject\` — the stack drives selection visuals.
- **refactor(document-state)** `5aab9d7` — introduces \`SelectionRoute\` enum + \`DocumentState.selectionRouter\` + \`DocumentState.routeSignal\` (a \`Signal<SelectionRoute>\` emitted after each mutation). \`MainCoordinator.fanOut(_:)\` is the single place that knows how each route affects each pane. Tears down its \`routeDisposeBag\` before triggering \`.switchEngine\` so the silent state reset never reaches the soon-to-be-discarded coordinators.
- **refactor(sidebar)** `1b926b7` — sidebar's pending-selection scroll observes \`documentState.\$selectionStack\` directly instead of being prompted by a separate \`selectRuntimeObject(_:)\` method.
- **refactor(document-state)** `f8c3009` — folds the route handling lambda into a dedicated private \`SelectionRouter: Router\` type so each mutation case lives next to the others.

### Notes
- Based on top of \`feat/inspector-relationships\` (#66) because \`SelectionRoute.drillInto\` is the route the relationships UI fires. Once #66 merges to \`main\`, this PR rebases naturally.
- \`MainRoute\` drops \`.select\` / \`.sidebarBack\` / \`.contentBack\` / \`.loadFramework\` — every caller routes through \`documentState.selectionRouter\` instead.
- The \`assertionFailure\` in \`MainCoordinator.fanOut\` for \`.switchEngine\` is intentional: \`.switchEngine\` is only triggered from the \`.main\` route handler, which tears down the subscription before triggering. Reaching the fan-out branch is a contract violation.

## Test plan
- [ ] \`swift build\` in \`RuntimeViewerCore\` succeeds.
- [ ] Workspace build of \`RuntimeViewer macOS\` succeeds.
- [ ] Manual: switch source (Local ↔ XPC ↔ Bonjour), confirm sidebar / content / inspector all clear together.
- [ ] Manual: drill into a runtime object's relationship from the Inspector, confirm content + inspector stacks push together; toolbar back button pops both.
- [ ] Manual: complete a Swift specialization, confirm the produced specialized object becomes the new root (replaces stack, not pushes).
- [ ] Manual: sidebar back button collapses the image picker, content + inspector return to placeholder.

Split from #62.