### PR TITLE
[codex] Fix export module metadata resolution

### DIFF
--- a/RuntimeViewerCore/Sources/RuntimeViewerCore/Export/RuntimeInterfaceExportMetadata.swift
+++ b/RuntimeViewerCore/Sources/RuntimeViewerCore/Export/RuntimeInterfaceExportMetadata.swift
@@ -61,6 +61,7 @@ struct RuntimeInterfaceExportMetadata: Codable, Sendable {
 
     static func make(
         configuration: RuntimeInterfaceExportConfiguration,
+        module: ModuleInfo? = nil,
         objcInterfaceCount: Int,
         swiftInterfaceCount: Int,
         succeeded: Int,
@@ -69,7 +70,7 @@ struct RuntimeInterfaceExportMetadata: Codable, Sendable {
     ) -> RuntimeInterfaceExportMetadata {
         RuntimeInterfaceExportMetadata(
             runtimeViewer: .current,
-            module: .resolve(imagePath: configuration.imagePath, imageName: configuration.imageName),
+            module: module ?? .resolve(imagePath: configuration.imagePath, imageName: configuration.imageName),
             export: .init(
                 generatedAt: generatedAt,
                 objcFormat: configuration.objcFormat.displayName,
@@ -408,15 +409,7 @@ private extension RuntimeInterfaceExportMetadata.RuntimeViewerInfo {
     }
 }
 
-private extension RuntimeInterfaceExportMetadata.ModuleInfo {
-    struct MachOVersionInfo {
-        var installName: String?
-        var currentVersion: String?
-        var compatibilityVersion: String?
-        var sourceVersion: String?
-        var uuid: String?
-    }
-
+extension RuntimeInterfaceExportMetadata.ModuleInfo {
     static func resolve(imagePath: String, imageName: String) -> Self {
         let resolvedPath = DyldUtilities.patchImagePathForDyld(imagePath)
         let displayedResolvedPath = resolvedPath == imagePath ? nil : resolvedPath
@@ -436,6 +429,16 @@ private extension RuntimeInterfaceExportMetadata.ModuleInfo {
             sourceVersion: machOInfo.sourceVersion,
             uuid: machOInfo.uuid
         )
+    }
+}
+
+private extension RuntimeInterfaceExportMetadata.ModuleInfo {
+    struct MachOVersionInfo {
+        var installName: String?
+        var currentVersion: String?
+        var compatibilityVersion: String?
+        var sourceVersion: String?
+        var uuid: String?
     }
 
     static func bundleInfo(forPath path: String) -> [String: String]? {
@@ -495,7 +498,7 @@ private extension RuntimeInterfaceExportMetadata.ModuleInfo {
     }
 
     static func machOVersionInfo(forPath imagePath: String, resolvedPath: String) -> MachOVersionInfo {
-        if let image = DyldUtilities.machOImage(forPath: imagePath) ?? DyldUtilities.machOImage(forPath: resolvedPath) {
+        if let image = DyldUtilities.exactMachOImage(forPath: imagePath) ?? DyldUtilities.exactMachOImage(forPath: resolvedPath) {
             return machOVersionInfo(for: image)
         }
 

--- a/RuntimeViewerCore/Sources/RuntimeViewerCore/RuntimeEngine+Requests.swift
+++ b/RuntimeViewerCore/Sources/RuntimeViewerCore/RuntimeEngine+Requests.swift
@@ -56,6 +56,19 @@ extension RuntimeEngine {
             nil
         }
     }
+
+    /// Resolves Mach-O / bundle metadata for the inspected image on the engine
+    /// that actually owns the image, so export README metadata is not polluted
+    /// by the macOS host process picking up a same-named framework via
+    /// `DyldUtilities`' basename fallback.
+    struct ExportModuleInfoRequest: RuntimeEngineRequest {
+        let imagePath: String
+        let imageName: String
+        static var commandName: String { CommandNames.runtimeInterfaceExportModuleInfo.commandName }
+        func perform(on engine: RuntimeEngine) async throws -> RuntimeInterfaceExportMetadata.ModuleInfo {
+            RuntimeInterfaceExportMetadata.ModuleInfo.resolve(imagePath: imagePath, imageName: imageName)
+        }
+    }
 }
 
 // MARK: - Objects & interfaces

--- a/RuntimeViewerCore/Sources/RuntimeViewerCore/RuntimeEngine.swift
+++ b/RuntimeViewerCore/Sources/RuntimeViewerCore/RuntimeEngine.swift
@@ -65,6 +65,7 @@ public actor RuntimeEngine {
         case runtimeObjectInfo
         case imageNameOfClassName
         case observeRuntime
+        case runtimeInterfaceExportModuleInfo
         case runtimeInterfaceForRuntimeObjectInImageWithOptions
         case runtimeObjectsOfKindInImage
         case runtimeObjectsInImage
@@ -320,7 +321,6 @@ public actor RuntimeEngine {
             #log(.default, "Connection is nil when setting up server message handlers")
             return
         }
-
         // Shared registry — same set of commands that
         // `RuntimeEngineProxyServer.setupRequestHandlers()` installs.
         Self.registerSharedHandlers(on: connection, engine: self)
@@ -902,8 +902,15 @@ extension RuntimeEngine {
             }
 
             if configuration.includeMetadata {
+                let module = try await dispatch(
+                    ExportModuleInfoRequest(
+                        imagePath: configuration.imagePath,
+                        imageName: configuration.imageName
+                    )
+                )
                 let metadata = RuntimeInterfaceExportMetadata.make(
                     configuration: configuration,
+                    module: module,
                     objcInterfaceCount: objcCount,
                     swiftInterfaceCount: swiftCount,
                     succeeded: succeeded,

--- a/RuntimeViewerCore/Sources/RuntimeViewerCore/RuntimeEngineRequest.swift
+++ b/RuntimeViewerCore/Sources/RuntimeViewerCore/RuntimeEngineRequest.swift
@@ -52,6 +52,7 @@ extension RuntimeEngine {
         register(RpathsRequest.self, on: connection, engine: engine)
         register(DependenciesRequest.self, on: connection, engine: engine)
         register(ImageNameOfObjectRequest.self, on: connection, engine: engine)
+        register(ExportModuleInfoRequest.self, on: connection, engine: engine)
         register(ObjectsInImageRequest.self, on: connection, engine: engine)
         register(InterfaceRequest.self, on: connection, engine: engine)
         register(HierarchyRequest.self, on: connection, engine: engine)

--- a/RuntimeViewerCore/Sources/RuntimeViewerCore/Utils/DyldUtilities.swift
+++ b/RuntimeViewerCore/Sources/RuntimeViewerCore/Utils/DyldUtilities.swift
@@ -121,15 +121,25 @@ package enum DyldUtilities {
     ///    a path whose exact spelling doesn't match dyld's registered form
     ///    (e.g. symlink-resolved vs. raw, or a bare framework name).
     package static func machOImage(forPath path: String) -> MachOImage? {
-        if path == mainExecutablePath(),
-           let debugDylib = loadedImage(forExactPath: path + ".debug.dylib") {
-            return debugDylib
-        }
-        if let exact = loadedImage(forExactPath: path) {
+        if let exact = exactMachOImage(forPath: path) {
             return exact
         }
         let imageName = path.lastPathComponent.deletingPathExtension.deletingPathExtension
         return MachOImage(name: imageName)
+    }
+
+    /// Resolves a filesystem path to a loaded `MachOImage` without basename
+    /// fallback.
+    ///
+    /// Export metadata must use exact matching only: when inspecting a remote
+    /// iOS simulator image from the macOS app process, a fuzzy basename match
+    /// can accidentally pick the host's same-named framework.
+    package static func exactMachOImage(forPath path: String) -> MachOImage? {
+        if path == mainExecutablePath(),
+           let debugDylib = loadedImage(forExactPath: path + ".debug.dylib") {
+            return debugDylib
+        }
+        return loadedImage(forExactPath: path)
     }
 
     /// Returns the loaded `MachOImage` whose dyld-registered path equals

--- a/RuntimeViewerCore/Tests/RuntimeViewerCoreTests/ExportTests.swift
+++ b/RuntimeViewerCore/Tests/RuntimeViewerCoreTests/ExportTests.swift
@@ -113,6 +113,45 @@ struct RuntimeInterfaceExportMetadataTests {
         #expect(readme.contains("- RuntimeViewer license: MIT License"))
     }
 
+    @Test("make uses engine-provided module metadata")
+    func makeUsesEngineProvidedModuleMetadata() {
+        let configuration = RuntimeInterfaceExportConfiguration(
+            imagePath: "/remote/System/Library/Frameworks/SwiftUICore.framework/SwiftUICore",
+            imageName: "SwiftUICore",
+            directory: FileManager.default.temporaryDirectory,
+            objcFormat: .singleFile,
+            swiftFormat: .singleFile,
+            generationOptions: .mcp
+        )
+        let module = RuntimeInterfaceExportMetadata.ModuleInfo(
+            name: "SwiftUICore",
+            path: "/remote/System/Library/Frameworks/SwiftUICore.framework/SwiftUICore",
+            resolvedPath: nil,
+            bundleIdentifier: "com.apple.SwiftUICore",
+            bundleShortVersion: "8.0.66.1.103",
+            bundleVersion: "8.0.66.1.103",
+            installName: "/System/Library/Frameworks/SwiftUICore.framework/SwiftUICore",
+            currentVersion: "8.0.66",
+            compatibilityVersion: "1.0.0",
+            sourceVersion: "1165.1.103",
+            uuid: "A8FC6D2D-DFE9-3557-A734-7F2B231F8C97"
+        )
+
+        let metadata = RuntimeInterfaceExportMetadata.make(
+            configuration: configuration,
+            module: module,
+            objcInterfaceCount: 1,
+            swiftInterfaceCount: 2,
+            succeeded: 3,
+            failed: 0,
+            generatedAt: Date(timeIntervalSince1970: 0)
+        )
+
+        #expect(metadata.module.installName == "/System/Library/Frameworks/SwiftUICore.framework/SwiftUICore")
+        #expect(metadata.module.currentVersion == "8.0.66")
+        #expect(metadata.module.sourceVersion == "1165.1.103")
+    }
+
     @Test("writer emits README only")
     func writerEmitsReadmeOnly() throws {
         let directory = FileManager.default.temporaryDirectory


### PR DESCRIPTION
## Summary

Fixes RuntimeViewer export metadata so Mach-O module metadata is resolved on the engine that actually owns the inspected image, rather than in the macOS host process.

## Root Cause

Export writing runs on the client side, but `RuntimeInterfaceExportMetadata` was resolving Mach-O metadata locally. For remote targets such as an iOS simulator, `DyldUtilities.machOImage(forPath:)` could fall through to basename matching and pick a same-named framework already loaded in the macOS host process, for example host `SwiftUICore`, producing incorrect `Mach-O current version` and `Mach-O source version` values.

## Changes

- Adds a `runtimeInterfaceExportModuleInfo` RuntimeEngine request so export metadata can be resolved by the target/remote engine.
- Uses the engine-provided `ModuleInfo` when building export README metadata.
- Adds exact-only Mach-O lookup for metadata resolution to avoid host basename fallback.
- Adds focused coverage for using engine-provided module metadata.

Fixes #75