### PR TITLE
feat(content): add line-number gutter to interface text view

### DIFF
--- a/RuntimeViewer.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/RuntimeViewer.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -19,21 +19,12 @@
       }
     },
     {
-      "identity" : "binarycodable",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/christophhagen/BinaryCodable",
-      "state" : {
-        "revision" : "c2ef4834bf038a998c36301d910a8525de5e12b1",
-        "version" : "3.2.0"
-      }
-    },
-    {
       "identity" : "cocoacoordinator",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Mx-Iris/CocoaCoordinator",
       "state" : {
-        "revision" : "8756b37cfc91918a6d92ba92125dd6f45e5a8aae",
-        "version" : "0.4.1"
+        "revision" : "7bfb995aafa0c802bb8296add707421e6950d1b0",
+        "version" : "0.5.0"
       }
     },
     {
@@ -86,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ukushu/Ifrit",
       "state" : {
-        "revision" : "9b9556e14cee24ad16b19d0eb099283cf79a7d94",
-        "version" : "3.0.0"
+        "revision" : "7c889a67bad90c5efefa56889b2d61bfbb831473",
+        "version" : "4.0.0"
       }
     },
     {
@@ -181,24 +172,6 @@
       }
     },
     {
-      "identity" : "runningapplicationkit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/Mx-Iris/RunningApplicationKit",
-      "state" : {
-        "revision" : "8c64a39bbcbe96b7758afd0e2e0a9f3d82f7305a",
-        "version" : "0.3.3"
-      }
-    },
-    {
-      "identity" : "rxappkit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/Mx-Iris/RxAppKit",
-      "state" : {
-        "revision" : "8194bca7c33b10f40d63894cf827890850390f04",
-        "version" : "0.4.0"
-      }
-    },
-    {
       "identity" : "rxcombine",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CombineCommunity/RxCombine",
@@ -244,15 +217,6 @@
       }
     },
     {
-      "identity" : "rxuikit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/Mx-Iris/RxUIKit",
-      "state" : {
-        "revision" : "f4397315d83edf4f9390dbe96e212c892577c7eb",
-        "version" : "0.1.1"
-      }
-    },
-    {
       "identity" : "semaphore",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/MxIris-Library-Forks/Semaphore",
@@ -275,17 +239,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SnapKit/SnapKit",
       "state" : {
-        "revision" : "2842e6e84e82eb9a8dac0100ca90d9444b0307f4",
-        "version" : "5.7.1"
-      }
-    },
-    {
-      "identity" : "sourcekitd",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/Mx-Iris/SourceKitD",
-      "state" : {
-        "revision" : "47ddc958a3962f9bb0fe08de1c8f39723e472228",
-        "version" : "0.1.0"
+        "revision" : "e27a338a03a5f388de759da63f9baf7988ed9e00",
+        "version" : "6.0.0"
       }
     },
     {
@@ -295,15 +250,6 @@
       "state" : {
         "revision" : "6276ba2b404829d139c45ff98427cf90e2efc59b",
         "version" : "2.9.2"
-      }
-    },
-    {
-      "identity" : "swift-apinotes",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/MxIris-DeveloperTool/swift-apinotes",
-      "state" : {
-        "revision" : "e762ac739f71adf83ed2e05f40211c96cd91f6c5",
-        "version" : "0.2.0"
       }
     },
     {
@@ -370,15 +316,6 @@
       }
     },
     {
-      "identity" : "swift-clang",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/MxIris-DeveloperTool/swift-clang",
-      "state" : {
-        "revision" : "89195b5191f6678da7e782cec24f2cbc8d75cf79",
-        "version" : "0.3.0"
-      }
-    },
-    {
       "identity" : "swift-clocks",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-clocks",
@@ -406,15 +343,6 @@
       }
     },
     {
-      "identity" : "swift-confidential",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/MxIris-Library-Forks/swift-confidential.git",
-      "state" : {
-        "revision" : "0e3e84cc18ffb4b39c4e51d9deacc3007e5fc67b",
-        "version" : "0.5.100"
-      }
-    },
-    {
       "identity" : "swift-crypto",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
@@ -437,17 +365,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-dependencies",
       "state" : {
-        "revision" : "706feb7858a7f6c242879d137b8ee30926aa5b26",
-        "version" : "1.12.0"
-      }
-    },
-    {
-      "identity" : "swift-dyld-private",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/MxIris-Reverse-Engineering/swift-dyld-private",
-      "state" : {
-        "revision" : "e9b255ed123e0ff5bb998d11639b993196159214",
-        "version" : "1.2.1"
+        "revision" : "16f7dd14ee28d04617090f2a73198b8b316ffa12",
+        "version" : "1.13.1"
       }
     },
     {
@@ -568,11 +487,20 @@
       }
     },
     {
+      "identity" : "swiftcross",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Cocoanetics/SwiftCross.git",
+      "state" : {
+        "revision" : "cc164b31ede7d2ee72af713b59c5d1f9be1556e0",
+        "version" : "1.2.0"
+      }
+    },
+    {
       "identity" : "swiftmcp",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Cocoanetics/SwiftMCP",
       "state" : {
-        "revision" : "5e8961f73834abb6f05fede365831a019a68be91",
+        "revision" : "d999fc379a96df25706c391b477c7f14d7552399",
         "version" : "1.4.7"
       }
     },
@@ -608,8 +536,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Mx-Iris/UIFoundation",
       "state" : {
-        "revision" : "d821c32ff9efa9aa13506c12457ea0d430110a20",
-        "version" : "0.10.0"
+        "revision" : "f2d5a1c66355ee19f46966dd1fb3954544428522",
+        "version" : "0.11.0"
       }
     },
     {
@@ -646,15 +574,6 @@
       "state" : {
         "revision" : "dfd70507def84cb5fb821278448a262c6ff2bbad",
         "version" : "1.9.0"
-      }
-    },
-    {
-      "identity" : "yams",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/jpsim/Yams",
-      "state" : {
-        "revision" : "a27b21e0c81c5bf42049b897a62aaf387e80f279",
-        "version" : "6.2.2"
       }
     }
   ],

--- a/RuntimeViewerCore/Package.resolved
+++ b/RuntimeViewerCore/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "de6647bb181ee8526ece5ade62a007eed83debc1ec4614eea0354aaab456c339",
+  "originHash" : "0d94912b116b4f8626c408e0efe7f5f0135d5441a8592861cb7f037bd8dfb368",
   "pins" : [
     {
       "identity" : "associatedobject",
@@ -53,33 +53,6 @@
       "state" : {
         "revision" : "138ed60c926868968bdb965ae2709f8dced2ee2d",
         "version" : "0.3.0"
-      }
-    },
-    {
-      "identity" : "machokit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/MxIris-Reverse-Engineering/MachOKit",
-      "state" : {
-        "revision" : "d83be31cca95efe72e39f914d35f1c4da799777e",
-        "version" : "0.50.100"
-      }
-    },
-    {
-      "identity" : "machoobjcsection",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/MxIris-Reverse-Engineering/MachOObjCSection",
-      "state" : {
-        "revision" : "63e4b8a61d54fe90bb30e87c0c93f6a8b9c181f9",
-        "version" : "0.7.103"
-      }
-    },
-    {
-      "identity" : "machoswiftsection",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/MxIris-Reverse-Engineering/MachOSwiftSection",
-      "state" : {
-        "revision" : "f17bc65b57f372b461fe45687298671c3400909e",
-        "version" : "0.12.0-beta.5"
       }
     },
     {
@@ -182,15 +155,6 @@
       }
     },
     {
-      "identity" : "swift-confidential",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/MxIris-Library-Forks/swift-confidential.git",
-      "state" : {
-        "revision" : "0e3e84cc18ffb4b39c4e51d9deacc3007e5fc67b",
-        "version" : "0.5.100"
-      }
-    },
-    {
       "identity" : "swift-crypto",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
@@ -200,30 +164,12 @@
       }
     },
     {
-      "identity" : "swift-demangling",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/MxIris-Reverse-Engineering/swift-demangling",
-      "state" : {
-        "revision" : "d32f3154b6a551728e06fe4d5ad3e8f9e83010f5",
-        "version" : "0.4.2"
-      }
-    },
-    {
       "identity" : "swift-dependencies",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-dependencies",
       "state" : {
         "revision" : "16f7dd14ee28d04617090f2a73198b8b316ffa12",
         "version" : "1.13.1"
-      }
-    },
-    {
-      "identity" : "swift-dyld-private",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/MxIris-Reverse-Engineering/swift-dyld-private",
-      "state" : {
-        "revision" : "e9b255ed123e0ff5bb998d11639b993196159214",
-        "version" : "1.2.1"
       }
     },
     {
@@ -242,15 +188,6 @@
       "state" : {
         "revision" : "8d83506dd4dff737807d90dbf2264096ed98c7a7",
         "version" : "0.2.2"
-      }
-    },
-    {
-      "identity" : "swift-helper-service",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/Mx-Iris/swift-helper-service",
-      "state" : {
-        "revision" : "d15e26aa1e96e03a72a913511e5cd19b96c2a3bf",
-        "version" : "0.1.3"
       }
     },
     {
@@ -281,30 +218,12 @@
       }
     },
     {
-      "identity" : "swift-objc-dump",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/MxIris-Reverse-Engineering/swift-objc-dump",
-      "state" : {
-        "revision" : "641d257d60385b231a608ab8c4ecdf31348c779e",
-        "version" : "0.8.101"
-      }
-    },
-    {
       "identity" : "swift-object-association",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/p-x9/swift-object-association.git",
       "state" : {
         "revision" : "93806cfecae1f198c894ed5585b93aff0e2d1f5a",
         "version" : "0.5.0"
-      }
-    },
-    {
-      "identity" : "swift-semantic-string",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/MxIris-Reverse-Engineering/swift-semantic-string",
-      "state" : {
-        "revision" : "1c3438861ea6dbba0856ab02071d683914468e82",
-        "version" : "0.1.1"
       }
     },
     {

--- a/RuntimeViewerCore/Package.swift
+++ b/RuntimeViewerCore/Package.swift
@@ -200,6 +200,7 @@ let package = Package(
                 .product(name: "MachOObjCSection", package: "MachOObjCSection"),
                 .product(name: "MachOSwiftSection", package: "MachOSwiftSection"),
                 .product(name: "SwiftDeclaration", package: "MachOSwiftSection"),
+                .product(name: "SwiftDeclarationRendering", package: "MachOSwiftSection"),
                 .product(name: "SwiftIndexing", package: "MachOSwiftSection"),
                 .product(name: "SwiftPrinting", package: "MachOSwiftSection"),
                 .product(name: "SwiftSpecialization", package: "MachOSwiftSection"),

--- a/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit.xcodeproj/project.pbxproj
+++ b/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		9677438C01BDD12085C27522 /* SpecializationTypePickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C6DBFCCFA6B22702BC7667 /* SpecializationTypePickerViewController.swift */; };
 		9CA80CE73BB3CFC59ED54FA9 /* BatchExportingImageSelectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDDE868F82139B514DD706D1 /* BatchExportingImageSelectionViewController.swift */; };
 		A2519448E7F7FA797E155C73 /* BatchExportingImageSelectionCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 061FB631FA9AEDDF6ED4549F /* BatchExportingImageSelectionCellViewModel.swift */; };
+		A8B5E79F7B4255321D573588 /* ContentLineNumberRulerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1475E54764442CF34D863334 /* ContentLineNumberRulerView.swift */; };
 		A9F67D4F08F37DE09A9772C2 /* BatchExportingCompletionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96DBB7C902543EF2B169FC99 /* BatchExportingCompletionViewModel.swift */; };
 		CB5EBCC699B082FC52857966 /* SpecializationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EC4339B0319BDED6270B85F /* SpecializationCoordinator.swift */; };
 		D16A49532E755901A1D32E5F /* BatchExportingState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FFA5EB1BB7210538B942D40 /* BatchExportingState.swift */; };
@@ -90,7 +91,7 @@
 		E9A825582C0E202600D9A85D /* MainViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9A825572C0E202600D9A85D /* MainViewModel.swift */; };
 		E9A9CCE02F5D880400A10DD3 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9B4C6542F35E9C800823FE0 /* main.swift */; };
 		E9A9CCE22F5D880400A10DD3 /* RuntimeViewerService in Frameworks */ = {isa = PBXBuildFile; productRef = E9A9CCDE2F5D880400A10DD3 /* RuntimeViewerService */; };
-		E9A9CCF12F5D884900A10DD3 /* embedded service product in Embed LaunchServices */ = {isa = PBXBuildFile; fileRef = E9CAFE020000000000000002 /* embedded service product (per-config name) */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		E9A9CCF12F5D884900A10DD3 /* $(RUNTIME_VIEWER_SERVICE_NAME) in Embed LaunchServices */ = {isa = PBXBuildFile; fileRef = E9CAFE020000000000000002 /* $(RUNTIME_VIEWER_SERVICE_NAME) */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		E9A9D7F62F5F110300A10DD3 /* MCPStatusPopoverViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9A9D7F52F5F110300A10DD3 /* MCPStatusPopoverViewController.swift */; };
 		E9AA36222C3089AB00A9B2E4 /* InspectorPlaceholderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9AA36212C3089AB00A9B2E4 /* InspectorPlaceholderViewController.swift */; };
 		E9BD1A112FA000020000ABCD /* BackgroundIndexingNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9BD1A102FA000010000ABCD /* BackgroundIndexingNode.swift */; };
@@ -169,15 +170,18 @@
 /* Begin PBXCopyFilesBuildPhase section */
 		E961FEEB2F54511E00ED3419 /* Copy RuntimeViewerServer Framework */ = {
 			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolder = Resources;
 			files = (
 				E961FEEC2F54513E00ED3419 /* RuntimeViewerServer.framework in Copy RuntimeViewerServer Framework */,
 			);
 			name = "Copy RuntimeViewerServer Framework";
+			runOnlyForDeploymentPostprocessing = 0;
 		};
 		E9A9CCE32F5D880400A10DD3 /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
 			dstPath = /usr/share/man/man1/;
 			dstSubfolder = None;
 			files = (
@@ -186,30 +190,36 @@
 		};
 		E9C9E9CC2C2D0F1B00C4AA34 /* Embed LaunchServices */ = {
 			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
 			dstPath = Contents/Library/LaunchServices;
 			dstSubfolder = Wrapper;
 			files = (
-				E9A9CCF12F5D884900A10DD3 /* embedded service product in Embed LaunchServices */,
+				E9A9CCF12F5D884900A10DD3 /* $(RUNTIME_VIEWER_SERVICE_NAME) in Embed LaunchServices */,
 			);
 			name = "Embed LaunchServices";
+			runOnlyForDeploymentPostprocessing = 0;
 		};
 		E9C9E9DA2C2D161000C4AA34 /* Embed PlugIns */ = {
 			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolder = PlugIns;
 			files = (
 				E9C9E9D72C2D161000C4AA34 /* RuntimeViewerCatalystHelperPlugin.bundle in Embed PlugIns */,
 			);
 			name = "Embed PlugIns";
+			runOnlyForDeploymentPostprocessing = 0;
 		};
 		E9C9E9EB2C2D33F500C4AA34 /* Embed Helpers */ = {
 			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
 			dstPath = ../Applications;
 			dstSubfolder = Executables;
 			files = (
 				E9381D032EC8BFDE007F6333 /* RuntimeViewerCatalystHelper.app in Embed Helpers */,
 			);
 			name = "Embed Helpers";
+			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXCopyFilesBuildPhase section */
 
@@ -217,6 +227,7 @@
 		061FB631FA9AEDDF6ED4549F /* BatchExportingImageSelectionCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatchExportingImageSelectionCellViewModel.swift; sourceTree = "<group>"; };
 		0809C7E1B5879399F4AD5CFD /* BatchExportingCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatchExportingCoordinator.swift; sourceTree = "<group>"; };
 		0FBD344C22E90BA7623E9663 /* SpecializationWindowController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SpecializationWindowController.swift; sourceTree = "<group>"; };
+		1475E54764442CF34D863334 /* ContentLineNumberRulerView.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; lastKnownFileType = sourcecode.swift; name = ContentLineNumberRulerView.swift; path = ContentLineNumberRulerView.swift; sourceTree = "<group>"; };
 		35D4C6E546DAF4CAF7E7AA37 /* BatchExportingCompletionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatchExportingCompletionViewController.swift; sourceTree = "<group>"; };
 		4C83BCFA7DEDB3FD171EB6C6 /* BatchExportingCompletionRowViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatchExportingCompletionRowViewModel.swift; sourceTree = "<group>"; };
 		5FFA5EB1BB7210538B942D40 /* BatchExportingState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatchExportingState.swift; sourceTree = "<group>"; };
@@ -265,7 +276,6 @@
 		E95CDA662DAA6FA900D97B03 /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = ../Configurations/RuntimeViewerService/Release.xcconfig; sourceTree = SOURCE_ROOT; };
 		E95CDA672DAA970300D97B03 /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = ../Configurations/RuntimeViewerUsingAppKit/Debug.xcconfig; sourceTree = SOURCE_ROOT; };
 		E95CDA682DAA970900D97B03 /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = ../Configurations/RuntimeViewerUsingAppKit/Release.xcconfig; sourceTree = SOURCE_ROOT; };
-		E9CAFE030000000000000003 /* Debug-arm64e.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = "Debug-arm64e.xcconfig"; path = "../Configurations/RuntimeViewerUsingAppKit/Debug-arm64e.xcconfig"; sourceTree = SOURCE_ROOT; };
 		E95D79C02F62A9EC0033D4CE /* RuntimeViewerUsingAppKit.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = RuntimeViewerUsingAppKit.xctestplan; sourceTree = "<group>"; };
 		E9668FFB2CEF7140007B344A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		E9668FFC2CEF7140007B344A /* launchd.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = launchd.plist; sourceTree = "<group>"; };
@@ -303,7 +313,6 @@
 		E9A825552C0E0FF300D9A85D /* ContentPlaceholderViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentPlaceholderViewController.swift; sourceTree = "<group>"; };
 		E9A825572C0E202600D9A85D /* MainViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewModel.swift; sourceTree = "<group>"; };
 		E9A9CCE72F5D880400A10DD3 /* dev.mxiris.runtimeviewer.service */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = dev.mxiris.runtimeviewer.service; sourceTree = BUILT_PRODUCTS_DIR; };
-		E9CAFE020000000000000002 /* embedded service product (per-config name) */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "$(RUNTIME_VIEWER_SERVICE_NAME)"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E9A9D7F52F5F110300A10DD3 /* MCPStatusPopoverViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPStatusPopoverViewController.swift; sourceTree = "<group>"; };
 		E9AA36212C3089AB00A9B2E4 /* InspectorPlaceholderViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InspectorPlaceholderViewController.swift; sourceTree = "<group>"; };
 		E9B4C6542F35E9C800823FE0 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
@@ -316,6 +325,8 @@
 		E9C9E9DB2C2D169D00C4AA34 /* AppKitPlugin.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppKitPlugin.swift; sourceTree = "<group>"; };
 		E9C9E9DC2C2D169D00C4AA34 /* AppKitPluginImpl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppKitPluginImpl.swift; sourceTree = "<group>"; };
 		E9C9E9EF2C2D379200C4AA34 /* RuntimeViewerCatalystHelper.app */ = {isa = PBXFileReference; lastKnownFileType = wrapper.application; path = RuntimeViewerCatalystHelper.app; sourceTree = "<group>"; };
+		E9CAFE020000000000000002 /* $(RUNTIME_VIEWER_SERVICE_NAME) */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "$(RUNTIME_VIEWER_SERVICE_NAME)"; sourceTree = BUILT_PRODUCTS_DIR; };
+		E9CAFE030000000000000003 /* Debug-arm64e.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = "Debug-arm64e.xcconfig"; path = "../Configurations/RuntimeViewerUsingAppKit/Debug-arm64e.xcconfig"; sourceTree = SOURCE_ROOT; };
 		E9CE07AE2C148FA00070A6E8 /* MainToolbarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainToolbarController.swift; sourceTree = "<group>"; };
 		E9CE07B82C1497B30070A6E8 /* SidebarRootTableCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarRootTableCellView.swift; sourceTree = "<group>"; };
 		E9D470622F12A52A008BF7A9 /* SidebarRootViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarRootViewController.swift; sourceTree = "<group>"; };
@@ -351,6 +362,7 @@
 /* Begin PBXFrameworksBuildPhase section */
 		E9432FDF2C0D614900362862 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
 			files = (
 				E9CB2C542F69B7D4005D2135 /* RuntimeViewerUtilities in Frameworks */,
 				E98BF62A2F1D4A750041DB20 /* RuntimeViewerCatalystExtensions in Frameworks */,
@@ -358,30 +370,39 @@
 				E942AC882C274DF600A2F3D3 /* RuntimeViewerApplication in Frameworks */,
 				E94EC5BECB0E94F4C6ABB6B3 /* Sparkle in Frameworks */,
 			);
+			runOnlyForDeploymentPostprocessing = 0;
 		};
 		E947C3642C2A4D0400296B2E /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
 			files = (
 			);
+			runOnlyForDeploymentPostprocessing = 0;
 		};
 		E9A9CCE12F5D880400A10DD3 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
 			files = (
 				E9A9CCE22F5D880400A10DD3 /* RuntimeViewerService in Frameworks */,
 			);
+			runOnlyForDeploymentPostprocessing = 0;
 		};
 		E9E900D92C2CF9A500FADDCC /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
 			files = (
 				E98BF6282F1D4A690041DB20 /* RuntimeViewerCatalystExtensions in Frameworks */,
 				E985A9CE2D9AF505005A573C /* RuntimeViewerCore in Frameworks */,
 			);
+			runOnlyForDeploymentPostprocessing = 0;
 		};
 		E9E900E52C2D0D5B00FADDCC /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
 			files = (
 				E985A9DA2D9AF7E5005A573C /* RuntimeViewerService in Frameworks */,
 			);
+			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
@@ -637,6 +658,7 @@
 				E9A825552C0E0FF300D9A85D /* ContentPlaceholderViewController.swift */,
 				E99E61602C129DC2002C1A3D /* ContentTextViewController.swift */,
 				E9EEF7642E08540B008D85D1 /* ContentTextView.swift */,
+				1475E54764442CF34D863334 /* ContentLineNumberRulerView.swift */,
 			);
 			path = Content;
 			sourceTree = "<group>";
@@ -796,6 +818,8 @@
 			);
 			buildRules = (
 			);
+			dependencies = (
+			);
 			name = com.mxiris.runtimeviewer.service;
 			packageProductDependencies = (
 				E9A9CCDE2F5D880400A10DD3 /* RuntimeViewerService */,
@@ -814,6 +838,8 @@
 			);
 			buildRules = (
 			);
+			dependencies = (
+			);
 			name = RuntimeViewerCatalystHelperPlugin;
 			packageProductDependencies = (
 				E985A9CD2D9AF505005A573C /* RuntimeViewerCore */,
@@ -831,6 +857,8 @@
 				E9E900E52C2D0D5B00FADDCC /* Frameworks */,
 			);
 			buildRules = (
+			);
+			dependencies = (
 			);
 			name = com.JH.RuntimeViewerService;
 			packageProductDependencies = (
@@ -916,23 +944,29 @@
 /* Begin PBXResourcesBuildPhase section */
 		E9432FE02C0D614900362862 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
 			files = (
 				E9432FE82C0D614A00362862 /* Assets.xcassets in Resources */,
 				E9432FEB2C0D614A00362862 /* Base in Resources */,
 				E975449A2C42BA5B00CC9DDD /* LoadFrameworksViewController.xib in Resources */,
 				E927C22E2E9444F300084A7B /* AppIcon.icon in Resources */,
 			);
+			runOnlyForDeploymentPostprocessing = 0;
 		};
 		E947C3652C2A4D0400296B2E /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
 			files = (
 				E947C3732C2A4D0500296B2E /* Assets.xcassets in Resources */,
 			);
+			runOnlyForDeploymentPostprocessing = 0;
 		};
 		E9E900DA2C2CF9A500FADDCC /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
 			files = (
 			);
+			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
 
@@ -940,45 +974,39 @@
 		E92988472F0D6A61001926A2 /* Update Build version */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
-			name = "Update Build version";
-			shellPath = /bin/sh;
-			shellScript = (
-				"#!/bin/bash",
-				"",
-				"#if [ \"${CONFIGURATION}\" = \"Release\" ]; then",
-				"#    buildNumber=$(date +\"%Y%m%d.%H.%M.%S\")",
-				"#    plistPath=\"${SRCROOT}/${INFOPLIST_FILE}\"",
-				"#    echo \"🚀 Release build detected. Updating Build Number to: $buildNumber\"",
-				"#    /usr/libexec/PlistBuddy -c \"Set :CFBundleVersion $buildNumber\" \"$plistPath\"",
-				"#else",
-				"#    echo \"⚠️ Debug build detected. Skipping Build Number update to keep Git clean.\"",
-				"#fi",
-				"",
+			buildActionMask = 2147483647;
+			inputPaths = (
 			);
+			name = "Update Build version";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "#!/bin/bash\n\n#if [ \"${CONFIGURATION}\" = \"Release\" ]; then\n#    buildNumber=$(date +\"%Y%m%d.%H.%M.%S\")\n#    plistPath=\"${SRCROOT}/${INFOPLIST_FILE}\"\n#    echo \"🚀 Release build detected. Updating Build Number to: $buildNumber\"\n#    /usr/libexec/PlistBuddy -c \"Set :CFBundleVersion $buildNumber\" \"$plistPath\"\n#else\n#    echo \"⚠️ Debug build detected. Skipping Build Number update to keep Git clean.\"\n#fi\n";
 		};
 		E92988482F0D6A86001926A2 /* Update Build version */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
-			name = "Update Build version";
-			shellPath = /bin/sh;
-			shellScript = (
-				"#!/bin/bash",
-				"",
-				"#if [ \"${CONFIGURATION}\" = \"Release\" ]; then",
-				"#    buildNumber=$(date +\"%Y%m%d.%H.%M.%S\")",
-				"#    plistPath=\"${SRCROOT}/${INFOPLIST_FILE}\"",
-				"#    echo \"🚀 Release build detected. Updating Build Number to: $buildNumber\"",
-				"#    /usr/libexec/PlistBuddy -c \"Set :CFBundleVersion $buildNumber\" \"$plistPath\"",
-				"#else",
-				"#    echo \"⚠️ Debug build detected. Skipping Build Number update to keep Git clean.\"",
-				"#fi",
-				"",
+			buildActionMask = 2147483647;
+			inputPaths = (
 			);
+			name = "Update Build version";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "#!/bin/bash\n\n#if [ \"${CONFIGURATION}\" = \"Release\" ]; then\n#    buildNumber=$(date +\"%Y%m%d.%H.%M.%S\")\n#    plistPath=\"${SRCROOT}/${INFOPLIST_FILE}\"\n#    echo \"🚀 Release build detected. Updating Build Number to: $buildNumber\"\n#    /usr/libexec/PlistBuddy -c \"Set :CFBundleVersion $buildNumber\" \"$plistPath\"\n#else\n#    echo \"⚠️ Debug build detected. Skipping Build Number update to keep Git clean.\"\n#fi\n";
 		};
 		E9CAFE010000000000000001 /* Generate LaunchDaemon plist */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			inputPaths = (
+			);
 			name = "Generate LaunchDaemon plist";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "set -e\nLAUNCHD_DIR=\"${TARGET_BUILD_DIR}/${CONTENTS_FOLDER_PATH}/Library/LaunchDaemons\"\nPLIST=\"${LAUNCHD_DIR}/${RUNTIME_VIEWER_SERVICE_NAME}.plist\"\nmkdir -p \"${LAUNCHD_DIR}\"\nrm -f \"${PLIST}\"\nprintf '%s\\n' '<?xml version=\"1.0\" encoding=\"UTF-8\"?>' '<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">' '<plist version=\"1.0\"><dict/></plist>' > \"${PLIST}\"\nPB=/usr/libexec/PlistBuddy\n\"${PB}\" -c \"Add :Label string ${RUNTIME_VIEWER_SERVICE_NAME}\" \"${PLIST}\"\n\"${PB}\" -c \"Add :BundleProgram string Contents/Library/LaunchServices/${RUNTIME_VIEWER_SERVICE_NAME}\" \"${PLIST}\"\n\"${PB}\" -c \"Add :KeepAlive bool true\" \"${PLIST}\"\n\"${PB}\" -c \"Add :MachServices dict\" \"${PLIST}\"\n\"${PB}\" -c \"Add :MachServices:${RUNTIME_VIEWER_SERVICE_NAME} bool true\" \"${PLIST}\"\necho \"Generated LaunchDaemon plist: ${PLIST}\"\n";
 		};
@@ -987,6 +1015,7 @@
 /* Begin PBXSourcesBuildPhase section */
 		E9432FDE2C0D614900362862 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
 			files = (
 				E9D470672F136E2A008BF7A9 /* SidebarRuntimeObjectListViewController.swift in Sources */,
 				E9432FE62C0D614900362862 /* AppDelegate.swift in Sources */,
@@ -1081,35 +1110,45 @@
 				A9F67D4F08F37DE09A9772C2 /* BatchExportingCompletionViewModel.swift in Sources */,
 				D9593A7A868FB627B0966159 /* BatchExportingCompletionViewController.swift in Sources */,
 				5A6BBD9C254FFE24540D71F9 /* BatchExportingProgressRowViewModel.swift in Sources */,
+				A8B5E79F7B4255321D573588 /* ContentLineNumberRulerView.swift in Sources */,
 			);
+			runOnlyForDeploymentPostprocessing = 0;
 		};
 		E947C3632C2A4D0400296B2E /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
 			files = (
 				E9C9E9E02C2D172600C4AA34 /* AppKitBridge.swift in Sources */,
 				E9C9E9DF2C2D16B000C4AA34 /* AppKitPlugin.swift in Sources */,
 				E947C36A2C2A4D0400296B2E /* AppDelegate.swift in Sources */,
 				E947C36C2C2A4D0400296B2E /* SceneDelegate.swift in Sources */,
 			);
+			runOnlyForDeploymentPostprocessing = 0;
 		};
 		E9A9CCDF2F5D880400A10DD3 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
 			files = (
 				E9A9CCE02F5D880400A10DD3 /* main.swift in Sources */,
 			);
+			runOnlyForDeploymentPostprocessing = 0;
 		};
 		E9E900D82C2CF9A500FADDCC /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
 			files = (
 				E9C9E9DE2C2D169D00C4AA34 /* AppKitPluginImpl.swift in Sources */,
 				E9C9E9DD2C2D169D00C4AA34 /* AppKitPlugin.swift in Sources */,
 			);
+			runOnlyForDeploymentPostprocessing = 0;
 		};
 		E9E900E42C2D0D5B00FADDCC /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
 			files = (
 				E9E900EB2C2D0D5B00FADDCC /* main.swift in Sources */,
 			);
+			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
@@ -1144,7 +1183,7 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
-		E9432FED2C0D614A00362862 /* Debug configuration for PBXProject "RuntimeViewerUsingAppKit" */ = {
+		E9432FED2C0D614A00362862 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = E9F2E9B92ED3BD3E001DCC3E /* CodeSigning.xcconfig */;
 			buildSettings = {
@@ -1212,7 +1251,7 @@
 			};
 			name = Debug;
 		};
-		E9432FEE2C0D614A00362862 /* Release configuration for PBXProject "RuntimeViewerUsingAppKit" */ = {
+		E9432FEE2C0D614A00362862 /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = E9F2E9B92ED3BD3E001DCC3E /* CodeSigning.xcconfig */;
 			buildSettings = {
@@ -1272,7 +1311,7 @@
 			};
 			name = Release;
 		};
-		E9432FF02C0D614A00362862 /* Debug configuration for PBXNativeTarget "RuntimeViewerUsingAppKit" */ = {
+		E9432FF02C0D614A00362862 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = E95CDA672DAA970300D97B03 /* Debug.xcconfig */;
 			buildSettings = {
@@ -1328,7 +1367,7 @@
 			};
 			name = Debug;
 		};
-		E9432FF12C0D614A00362862 /* Release configuration for PBXNativeTarget "RuntimeViewerUsingAppKit" */ = {
+		E9432FF12C0D614A00362862 /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = E95CDA682DAA970900D97B03 /* Release.xcconfig */;
 			buildSettings = {
@@ -1383,7 +1422,7 @@
 			};
 			name = Release;
 		};
-		E947C3782C2A4D0500296B2E /* Debug configuration for PBXNativeTarget "RuntimeViewerCatalystHelper" */ = {
+		E947C3782C2A4D0500296B2E /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALLOW_TARGET_PLATFORM_SPECIALIZATION = NO;
@@ -1429,7 +1468,7 @@
 			};
 			name = Debug;
 		};
-		E947C3792C2A4D0500296B2E /* Release configuration for PBXNativeTarget "RuntimeViewerCatalystHelper" */ = {
+		E947C3792C2A4D0500296B2E /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALLOW_TARGET_PLATFORM_SPECIALIZATION = NO;
@@ -1476,7 +1515,7 @@
 			};
 			name = Release;
 		};
-		E9958CD62FAB79100073036F /* Debug-arm64e configuration for PBXProject "RuntimeViewerUsingAppKit" */ = {
+		E9958CD62FAB79100073036F /* Debug-arm64e */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = E9F2E9B92ED3BD3E001DCC3E /* CodeSigning.xcconfig */;
 			buildSettings = {
@@ -1544,7 +1583,7 @@
 			};
 			name = "Debug-arm64e";
 		};
-		E9958CD72FAB79100073036F /* Debug-arm64e configuration for PBXNativeTarget "RuntimeViewerUsingAppKit" */ = {
+		E9958CD72FAB79100073036F /* Debug-arm64e */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = E9CAFE030000000000000003 /* Debug-arm64e.xcconfig */;
 			buildSettings = {
@@ -1599,7 +1638,7 @@
 			};
 			name = "Debug-arm64e";
 		};
-		E9958CD82FAB79100073036F /* Debug-arm64e configuration for PBXNativeTarget "RuntimeViewerCatalystHelper" */ = {
+		E9958CD82FAB79100073036F /* Debug-arm64e */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALLOW_TARGET_PLATFORM_SPECIALIZATION = NO;
@@ -1644,7 +1683,7 @@
 			};
 			name = "Debug-arm64e";
 		};
-		E9958CD92FAB79100073036F /* Debug-arm64e configuration for PBXNativeTarget "RuntimeViewerCatalystHelperPlugin" */ = {
+		E9958CD92FAB79100073036F /* Debug-arm64e */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
@@ -1669,7 +1708,7 @@
 			};
 			name = "Debug-arm64e";
 		};
-		E9958CDA2FAB79100073036F /* Debug-arm64e configuration for PBXNativeTarget "com.JH.RuntimeViewerService" */ = {
+		E9958CDA2FAB79100073036F /* Debug-arm64e */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = E95CDA652DAA6FA300D97B03 /* Debug.xcconfig */;
 			buildSettings = {
@@ -1688,7 +1727,7 @@
 			};
 			name = "Debug-arm64e";
 		};
-		E9958CDB2FAB79100073036F /* Debug-arm64e configuration for PBXNativeTarget "com.mxiris.runtimeviewer.service" */ = {
+		E9958CDB2FAB79100073036F /* Debug-arm64e */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
@@ -1704,7 +1743,7 @@
 			};
 			name = "Debug-arm64e";
 		};
-		E9A9CCE52F5D880400A10DD3 /* Debug configuration for PBXNativeTarget "com.mxiris.runtimeviewer.service" */ = {
+		E9A9CCE52F5D880400A10DD3 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
@@ -1720,7 +1759,7 @@
 			};
 			name = Debug;
 		};
-		E9A9CCE62F5D880400A10DD3 /* Release configuration for PBXNativeTarget "com.mxiris.runtimeviewer.service" */ = {
+		E9A9CCE62F5D880400A10DD3 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD)";
@@ -1737,7 +1776,7 @@
 			};
 			name = Release;
 		};
-		E9E900DE2C2CF9A500FADDCC /* Debug configuration for PBXNativeTarget "RuntimeViewerCatalystHelperPlugin" */ = {
+		E9E900DE2C2CF9A500FADDCC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
@@ -1763,7 +1802,7 @@
 			};
 			name = Debug;
 		};
-		E9E900DF2C2CF9A500FADDCC /* Release configuration for PBXNativeTarget "RuntimeViewerCatalystHelperPlugin" */ = {
+		E9E900DF2C2CF9A500FADDCC /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
@@ -1789,7 +1828,7 @@
 			};
 			name = Release;
 		};
-		E9E900ED2C2D0D5B00FADDCC /* Debug configuration for PBXNativeTarget "com.JH.RuntimeViewerService" */ = {
+		E9E900ED2C2D0D5B00FADDCC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = E95CDA652DAA6FA300D97B03 /* Debug.xcconfig */;
 			buildSettings = {
@@ -1809,7 +1848,7 @@
 			};
 			name = Debug;
 		};
-		E9E900EE2C2D0D5B00FADDCC /* Release configuration for PBXNativeTarget "com.JH.RuntimeViewerService" */ = {
+		E9E900EE2C2D0D5B00FADDCC /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = E95CDA662DAA6FA900D97B03 /* Release.xcconfig */;
 			buildSettings = {
@@ -1834,55 +1873,61 @@
 		E9432FDD2C0D614900362862 /* Build configuration list for PBXProject "RuntimeViewerUsingAppKit" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				E9432FED2C0D614A00362862 /* Debug configuration for PBXProject "RuntimeViewerUsingAppKit" */,
-				E9958CD62FAB79100073036F /* Debug-arm64e configuration for PBXProject "RuntimeViewerUsingAppKit" */,
-				E9432FEE2C0D614A00362862 /* Release configuration for PBXProject "RuntimeViewerUsingAppKit" */,
+				E9432FED2C0D614A00362862 /* Debug */,
+				E9958CD62FAB79100073036F /* Debug-arm64e */,
+				E9432FEE2C0D614A00362862 /* Release */,
 			);
+			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 		E9432FEF2C0D614A00362862 /* Build configuration list for PBXNativeTarget "RuntimeViewerUsingAppKit" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				E9432FF02C0D614A00362862 /* Debug configuration for PBXNativeTarget "RuntimeViewerUsingAppKit" */,
-				E9958CD72FAB79100073036F /* Debug-arm64e configuration for PBXNativeTarget "RuntimeViewerUsingAppKit" */,
-				E9432FF12C0D614A00362862 /* Release configuration for PBXNativeTarget "RuntimeViewerUsingAppKit" */,
+				E9432FF02C0D614A00362862 /* Debug */,
+				E9958CD72FAB79100073036F /* Debug-arm64e */,
+				E9432FF12C0D614A00362862 /* Release */,
 			);
+			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 		E947C37A2C2A4D0500296B2E /* Build configuration list for PBXNativeTarget "RuntimeViewerCatalystHelper" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				E947C3782C2A4D0500296B2E /* Debug configuration for PBXNativeTarget "RuntimeViewerCatalystHelper" */,
-				E9958CD82FAB79100073036F /* Debug-arm64e configuration for PBXNativeTarget "RuntimeViewerCatalystHelper" */,
-				E947C3792C2A4D0500296B2E /* Release configuration for PBXNativeTarget "RuntimeViewerCatalystHelper" */,
+				E947C3782C2A4D0500296B2E /* Debug */,
+				E9958CD82FAB79100073036F /* Debug-arm64e */,
+				E947C3792C2A4D0500296B2E /* Release */,
 			);
+			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 		E9A9CCE42F5D880400A10DD3 /* Build configuration list for PBXNativeTarget "com.mxiris.runtimeviewer.service" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				E9A9CCE52F5D880400A10DD3 /* Debug configuration for PBXNativeTarget "com.mxiris.runtimeviewer.service" */,
-				E9958CDB2FAB79100073036F /* Debug-arm64e configuration for PBXNativeTarget "com.mxiris.runtimeviewer.service" */,
-				E9A9CCE62F5D880400A10DD3 /* Release configuration for PBXNativeTarget "com.mxiris.runtimeviewer.service" */,
+				E9A9CCE52F5D880400A10DD3 /* Debug */,
+				E9958CDB2FAB79100073036F /* Debug-arm64e */,
+				E9A9CCE62F5D880400A10DD3 /* Release */,
 			);
+			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 		E9E900DD2C2CF9A500FADDCC /* Build configuration list for PBXNativeTarget "RuntimeViewerCatalystHelperPlugin" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				E9E900DE2C2CF9A500FADDCC /* Debug configuration for PBXNativeTarget "RuntimeViewerCatalystHelperPlugin" */,
-				E9958CD92FAB79100073036F /* Debug-arm64e configuration for PBXNativeTarget "RuntimeViewerCatalystHelperPlugin" */,
-				E9E900DF2C2CF9A500FADDCC /* Release configuration for PBXNativeTarget "RuntimeViewerCatalystHelperPlugin" */,
+				E9E900DE2C2CF9A500FADDCC /* Debug */,
+				E9958CD92FAB79100073036F /* Debug-arm64e */,
+				E9E900DF2C2CF9A500FADDCC /* Release */,
 			);
+			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 		E9E900EC2C2D0D5B00FADDCC /* Build configuration list for PBXNativeTarget "com.JH.RuntimeViewerService" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				E9E900ED2C2D0D5B00FADDCC /* Debug configuration for PBXNativeTarget "com.JH.RuntimeViewerService" */,
-				E9958CDA2FAB79100073036F /* Debug-arm64e configuration for PBXNativeTarget "com.JH.RuntimeViewerService" */,
-				E9E900EE2C2D0D5B00FADDCC /* Release configuration for PBXNativeTarget "com.JH.RuntimeViewerService" */,
+				E9E900ED2C2D0D5B00FADDCC /* Debug */,
+				E9958CDA2FAB79100073036F /* Debug-arm64e */,
+				E9E900EE2C2D0D5B00FADDCC /* Release */,
 			);
+			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */

--- a/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit.xcodeproj/xcshareddata/xcschemes/RuntimeViewer macOS.xcscheme
+++ b/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit.xcodeproj/xcshareddata/xcschemes/RuntimeViewer macOS.xcscheme
@@ -30,10 +30,12 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <TestPlans>
          <TestPlanReference
-            reference = "container:RuntimeViewerUsingAppKit.xctestplan"
-            default = "YES">
+            default = "YES"
+            reference = "container:RuntimeViewerUsingAppKit.xctestplan">
          </TestPlanReference>
       </TestPlans>
+      <Testables>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit/Base/RuntimeObjectCellView.swift
+++ b/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit/Base/RuntimeObjectCellView.swift
@@ -35,23 +35,33 @@ final class RuntimeObjectCellView<ViewModel: RuntimeObjectCellDisplayable>: Tabl
 
     private lazy var textStackView = VStackView(distribution: .fill, alignment: .leading, spacing: 2) {
         titleLabel
+            .box
             .contentCompressionResistance(h: .defaultLow)
         subtitleLabel
+            .box
             .contentCompressionResistance(h: .defaultLow)
     }
 
     private lazy var contentStackView = HStackView(distribution: .fill, spacing: 6) {
         primaryIconImageView
+            .box
             .contentHugging(h: .required)
+            .box
             .contentCompressionResistance(h: .required)
         secondaryIconImageView
+            .box
             .contentHugging(h: .required)
+            .box
             .contentCompressionResistance(h: .required)
         tertiaryIconImageView
+            .box
             .contentHugging(h: .required)
+            .box
             .contentCompressionResistance(h: .required)
         textStackView
+            .box
             .contentHugging(h: .defaultLow)
+            .box
             .contentCompressionResistance(h: .defaultLow)
     }
 

--- a/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit/BatchExporting/BatchExportingImageSelectionViewController.swift
+++ b/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit/BatchExporting/BatchExportingImageSelectionViewController.swift
@@ -132,10 +132,14 @@ extension BatchExportingImageSelectionViewController {
 
         private lazy var textStack = VStackView(alignment: .leading, spacing: 2) {
             nameLabel
+                .box
                 .contentHugging(h: .defaultLow)
+                .box
                 .contentCompressionResistance(h: .defaultLow)
             pathLabel
+                .box
                 .contentHugging(h: .defaultLow)
+                .box
                 .contentCompressionResistance(h: .defaultLow)
         }
 

--- a/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit/Content/ContentLineNumberRulerView.swift
+++ b/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit/Content/ContentLineNumberRulerView.swift
@@ -1,0 +1,261 @@
+import AppKit
+import RuntimeViewerUI
+
+/// A vertical line-number gutter rendered as an `NSRulerView` for a TextKit 2 `NSTextView`.
+///
+/// Line numbers are aligned to each paragraph by enumerating the visible `NSTextLayoutFragment`s
+/// of the client text view's `NSTextLayoutManager`. A soft-wrapped paragraph spans multiple
+/// `NSTextLineFragment`s but shares a single number drawn on its first line fragment, matching
+/// Xcode's gutter behaviour.
+///
+/// The ruler owns everything intrinsic to its own rendering — scroll tracking and reflow tracking
+/// are handled internally through clip-view bounds and text-view frame notifications. Content and
+/// theme updates are pushed in by the owning view controller via ``reload()`` and ``backgroundColor``.
+final class ContentLineNumberRulerView: NSRulerView {
+    /// Horizontal padding between the line numbers and the gutter edges.
+    private let horizontalPadding: CGFloat = 5
+
+    /// The minimum thickness of the gutter regardless of digit count.
+    private let minimumThickness: CGFloat = 32
+
+    /// Width of the trailing separator line.
+    private let separatorWidth: CGFloat = 1
+
+    /// Background color of the gutter, kept in sync with the editor background by the controller.
+    var backgroundColor: NSColor = .textBackgroundColor {
+        didSet {
+            guard backgroundColor != oldValue else { return }
+            needsDisplay = true
+        }
+    }
+
+    /// Color used to draw the line numbers.
+    var lineNumberColor: NSColor = NSColor(light: NSColor(white: 0.6, alpha: 1), dark: NSColor(white: 0.46, alpha: 1)) {
+        didSet {
+            guard lineNumberColor != oldValue else { return }
+            needsDisplay = true
+        }
+    }
+
+    /// Color of the trailing separator line.
+    var separatorColor: NSColor = NSColor(light: NSColor(white: 0.85, alpha: 1), dark: NSColor(white: 0.26, alpha: 1)) {
+        didSet {
+            guard separatorColor != oldValue else { return }
+            needsDisplay = true
+        }
+    }
+
+    /// Character offsets where each line begins, used to resolve a fragment's 1-based line number.
+    private var lineStartOffsets: [Int] = [0]
+
+    private var textView: NSTextView? { clientView as? NSTextView }
+
+    private var notificationObservers: [NSObjectProtocol] = []
+
+    // MARK: - Init
+
+    override init(scrollView: NSScrollView?, orientation: NSRulerView.Orientation) {
+        super.init(scrollView: scrollView, orientation: orientation)
+        clipsToBounds = true
+        reservedThicknessForMarkers = 0
+        reservedThicknessForAccessoryView = 0
+        ruleThickness = minimumThickness
+    }
+
+    @available(*, unavailable)
+    required init(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    deinit {
+        removeNotificationObservers()
+    }
+
+    // MARK: - Client View
+
+    override var clientView: NSView? {
+        didSet {
+            guard clientView !== oldValue else { return }
+            setupNotificationObservers()
+            reload()
+        }
+    }
+
+    // MARK: - Content
+
+    /// Rebuilds the line-start cache, recomputes the gutter thickness, and requests a redraw.
+    ///
+    /// The owning controller calls this after replacing the text view's content (which also covers
+    /// font-size changes, since those flow through a freshly rendered attributed string).
+    func reload() {
+        rebuildLineStartOffsets()
+        updateThickness()
+        needsDisplay = true
+    }
+
+    private func rebuildLineStartOffsets() {
+        guard let string = textView?.textStorage?.string, !string.isEmpty else {
+            lineStartOffsets = [0]
+            return
+        }
+        let text = string as NSString
+        let length = text.length
+        var offsets: [Int] = [0]
+        var searchStart = 0
+        while searchStart < length {
+            let newlineRange = text.range(of: "\n", options: [], range: NSRange(location: searchStart, length: length - searchStart))
+            guard newlineRange.location != NSNotFound else { break }
+            let nextLineStart = newlineRange.location + newlineRange.length
+            offsets.append(nextLineStart)
+            searchStart = nextLineStart
+        }
+        lineStartOffsets = offsets
+    }
+
+    private func updateThickness() {
+        let lineCount = max(lineStartOffsets.count, 1)
+        let widestNumber = String(repeating: "9", count: String(lineCount).count) as NSString
+        let textWidth = widestNumber.size(withAttributes: [.font: lineNumberFont]).width
+        let newThickness = max(minimumThickness, ceil(textWidth) + horizontalPadding * 2)
+        if abs(newThickness - ruleThickness) > 0.5 {
+            ruleThickness = newThickness
+        }
+    }
+
+    /// The font used for line numbers, derived from the rendered text so it tracks font-size changes.
+    private var lineNumberFont: NSFont {
+        let defaultSize = NSFont.systemFontSize
+        guard let textStorage = textView?.textStorage,
+              textStorage.length > 0,
+              let font = textStorage.attribute(.font, at: 0, effectiveRange: nil) as? NSFont
+        else {
+            return .monospacedSystemFont(ofSize: defaultSize, weight: .regular)
+        }
+        return .monospacedSystemFont(ofSize: font.pointSize, weight: .regular)
+    }
+
+    /// Resolves the 1-based line number for a character offset via binary search over the line-start cache.
+    private func lineNumber(for offset: Int) -> Int {
+        var low = 0
+        var high = lineStartOffsets.count - 1
+        var result = 0
+        while low <= high {
+            let middle = (low + high) / 2
+            if lineStartOffsets[middle] <= offset {
+                result = middle
+                low = middle + 1
+            } else {
+                high = middle - 1
+            }
+        }
+        return result + 1
+    }
+
+    // MARK: - Drawing
+
+    override func drawHashMarksAndLabels(in rect: NSRect) {
+        backgroundColor.setFill()
+        bounds.fill()
+
+        drawLineNumbers()
+        drawSeparator()
+    }
+
+    private func drawLineNumbers() {
+        guard let textView,
+              let textLayoutManager = textView.textLayoutManager,
+              let textContentManager = textLayoutManager.textContentManager
+        else { return }
+
+        let font = lineNumberFont
+        let numberAttributes: [NSAttributedString.Key: Any] = [
+            .font: font,
+            .foregroundColor: lineNumberColor,
+        ]
+
+        // `relativePoint` maps the text view's origin into the ruler's (flipped) coordinate space,
+        // absorbing the current scroll offset; adding a container-space y yields the ruler y.
+        let relativePoint = convert(NSPoint.zero, from: textView)
+        let containerOrigin = textView.textContainerOrigin
+
+        let visibleRect = textView.visibleRect
+        let visibleMinYInContainer = visibleRect.minY - containerOrigin.y
+        let visibleMaxYInContainer = visibleRect.maxY - containerOrigin.y
+
+        let documentStart = textLayoutManager.documentRange.location
+        let startLocation = textLayoutManager
+            .textLayoutFragment(for: CGPoint(x: 0, y: max(visibleMinYInContainer, 0)))?
+            .rangeInElement.location ?? documentStart
+
+        // One layout fragment == one paragraph, so the line number simply increments per fragment.
+        // It is resolved once for the first visible fragment, then advanced.
+        var currentLineNumber: Int?
+
+        textLayoutManager.enumerateTextLayoutFragments(from: startLocation, options: [.ensuresLayout, .ensuresExtraLineFragment]) { [weak self] fragment in
+            guard let self else { return false }
+            let fragmentFrame = fragment.layoutFragmentFrame
+            guard fragmentFrame.minY <= visibleMaxYInContainer else { return false }
+
+            let lineNumber: Int
+            if let currentLineNumber {
+                lineNumber = currentLineNumber
+            } else {
+                let offset = textContentManager.offset(from: documentStart, to: fragment.rangeInElement.location)
+                lineNumber = self.lineNumber(for: offset)
+            }
+            currentLineNumber = lineNumber + 1
+
+            let lineHeight = fragment.textLineFragments.first?.typographicBounds.height ?? fragmentFrame.height
+            let numberString = NSAttributedString(string: "\(lineNumber)", attributes: numberAttributes)
+            let numberSize = numberString.size()
+            let drawX = ruleThickness - numberSize.width - horizontalPadding
+            let drawY = (relativePoint.y + containerOrigin.y + fragmentFrame.minY + (lineHeight - numberSize.height) / 2).rounded()
+            numberString.draw(at: NSPoint(x: drawX, y: drawY))
+            return true
+        }
+    }
+
+    private func drawSeparator() {
+        separatorColor.setFill()
+        let separatorRect = NSRect(x: bounds.maxX - separatorWidth, y: bounds.minY, width: separatorWidth, height: bounds.height)
+        separatorRect.fill()
+    }
+
+    // MARK: - Notification Observers
+
+    private func setupNotificationObservers() {
+        removeNotificationObservers()
+
+        // Redraw in lockstep with scrolling. `queue: nil` keeps the callback synchronous on the
+        // posting (main) thread so the numbers never lag a frame behind the text.
+        if let contentView = scrollView?.contentView {
+            contentView.postsBoundsChangedNotifications = true
+            let observer = NotificationCenter.default.addObserver(
+                forName: NSView.boundsDidChangeNotification,
+                object: contentView,
+                queue: nil
+            ) { [weak self] _ in
+                self?.needsDisplay = true
+            }
+            notificationObservers.append(observer)
+        }
+
+        // Redraw when the text reflows (window resize, width-tracking container changes height).
+        if let textView {
+            textView.postsFrameChangedNotifications = true
+            let observer = NotificationCenter.default.addObserver(
+                forName: NSView.frameDidChangeNotification,
+                object: textView,
+                queue: nil
+            ) { [weak self] _ in
+                self?.needsDisplay = true
+            }
+            notificationObservers.append(observer)
+        }
+    }
+
+    private func removeNotificationObservers() {
+        notificationObservers.forEach { NotificationCenter.default.removeObserver($0) }
+        notificationObservers.removeAll()
+    }
+}

--- a/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit/Content/ContentTextViewController.swift
+++ b/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit/Content/ContentTextViewController.swift
@@ -34,6 +34,8 @@ final class ContentTextViewController: UXKitViewController<ContentTextViewModel>
         return (scrollView, textView)
     }()
 
+    private lazy var lineNumberRulerView = ContentLineNumberRulerView(scrollView: scrollView, orientation: .verticalRuler)
+
     private let eventMonitor = EventMonitor()
 
     private let jumpToDefinitionRelay = PublishRelay<RuntimeObject>()
@@ -54,6 +56,9 @@ final class ContentTextViewController: UXKitViewController<ContentTextViewModel>
 
         scrollView.do {
             $0.drawsBackground = true
+            $0.hasVerticalRuler = true
+            $0.verticalRulerView = lineNumberRulerView
+            $0.rulersVisible = true
         }
 
         textView.do {
@@ -64,6 +69,8 @@ final class ContentTextViewController: UXKitViewController<ContentTextViewModel>
             $0.linkTextAttributes = [:]
             $0.delegate = self
         }
+
+        lineNumberRulerView.clientView = textView
     }
 
 
@@ -88,6 +95,7 @@ final class ContentTextViewController: UXKitViewController<ContentTextViewModel>
 
         output.attributedString.drive(with: self) { target, attributedString in
             target.textView.textStorage?.setAttributedString(attributedString)
+            target.lineNumberRulerView.reload()
         }
         .disposed(by: rx.disposeBag)
 
@@ -95,6 +103,7 @@ final class ContentTextViewController: UXKitViewController<ContentTextViewModel>
             ($0.contentView as? UXView)?.backgroundColor = $1.backgroundColor
             $0.textView.backgroundColor = $1.backgroundColor
             $0.scrollView.backgroundColor = $1.backgroundColor
+            $0.lineNumberRulerView.backgroundColor = $1.backgroundColor
         }
         .disposed(by: rx.disposeBag)
 

--- a/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit/Exporting/ExportingCompletionViewController.swift
+++ b/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit/Exporting/ExportingCompletionViewController.swift
@@ -29,9 +29,11 @@ final class ExportingCompletionViewController: UXKitViewController<ExportingComp
 
     private lazy var contentStackView = VStackView(distribution: .fill, spacing: 10) {
         checkmarkImageView
+            .stackView
             .customSpacing(24)
         titleLabel
         summaryLabel
+            .stackView
             .customSpacing(16)
         showInFinderButton
     }

--- a/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit/Sidebar/RuntimeObject/SidebarRuntimeObjectViewController.swift
+++ b/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit/Sidebar/RuntimeObject/SidebarRuntimeObjectViewController.swift
@@ -380,8 +380,10 @@ extension SidebarRuntimeObjectViewController {
 
         lazy var contentView = VStackView(alignment: .center, spacing: 10) {
             titleLabel
+                .stackView
                 .gravity(.center)
             loadImageButton
+                .stackView
                 .gravity(.center)
         }
 


### PR DESCRIPTION
## Summary
- Add a line-number ruler/gutter to the interface text view in the Content pane (`ContentLineNumberRulerView`) so users can see line numbers alongside generated interfaces.
- Refactor AppKit stack-view layout to route modifiers through `.box` / `.stackView` accessors for consistency.
- Add the `SwiftDeclarationRendering` SPM product and refresh resolved package pins.

## Test plan
- [ ] Open a document, generate an interface, and verify the line-number gutter renders correctly and updates on scroll/resize.
- [ ] Toggle between Objective-C and Swift outputs; confirm numbering stays in sync with the visible lines.
- [ ] Verify other UI flows touched by the stack-view refactor (sidebar, exporting, inspector) still lay out as before.
- [ ] Build `RuntimeViewer macOS` Debug and run on Apple Silicon to confirm no regressions.