### PR TITLE
docs: clarify Runtime Viewer installation and source discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,21 @@
 
 ## Getting Started
 
+### Install Runtime Viewer
+
+Download the macOS release archive from [GitHub Releases](https://github.com/MxIris-Reverse-Engineering/RuntimeViewer/releases/latest), extract it, and move **RuntimeViewer.app** to your Applications folder. GitHub Releases is the official source for prebuilt versions of Runtime Viewer. The project does not publish a Homebrew cask; any such cask is unofficial and unsupported. See [Requirements](#requirements) for supported macOS versions.
+
+### Choose a Runtime Source
+
+Runtime Viewer does not automatically list every application on your Mac. After launching it, choose one of these ways to obtain content:
+
+- Browse the bundled **Local Runtime** source to inspect the local runtime and framework directory.
+- Use **Attach Process** in the toolbar to explicitly attach to a running process. Process attachment requires System Integrity Protection (SIP) to be disabled; see [Requirements](#requirements) and [Troubleshooting](#troubleshooting).
+- Select another Runtime Viewer instance discovered on your local network. See [Connecting to Other Devices](#connecting-to-other-devices) for Bonjour details.
+
 ### Helper Service Installation
 
-On first launch, register the `SMAppService` helper for inter-process communication and code injection. Open **Settings → Helper Service** and click **Install**. After major updates, Runtime Viewer detects version mismatches and prompts for reinstallation automatically.
+To enable inter-process communication and code injection, register the `SMAppService` helper from **Settings → Helper Service** by clicking **Install**. Installing the helper does not install the main app or automatically create connection targets. After major updates, Runtime Viewer detects version mismatches and prompts for reinstallation automatically.
 
 ### MCP Client Configuration
 
@@ -84,6 +96,7 @@ If Catalyst or code-injected applications don't appear in the directory list, tr
 ## Requirements
 
 - **Main application**: macOS 15+
+- **Process attachment**: System Integrity Protection (SIP) disabled
 - **RuntimeViewerCore** (inspection engine): macOS 10.15+, iOS 13+, Mac Catalyst 13+, watchOS 6+, tvOS 13+, visionOS 1+
 - **MCP integration**: macOS 15+
 - **Build toolchain**: Xcode 26.2+ (Swift 5 language mode)


### PR DESCRIPTION
Issue #83 reports an empty initial experience after installing an unofficial Homebrew cask, registering the helper service, and expecting applications to appear as connection targets. The maintainer clarified that Runtime Viewer is not published through Homebrew and directed users to GitHub Releases, but the README's Getting Started section currently begins with helper registration and never states how to install the main app. It also does not clearly distinguish the bundled local runtime source, explicitly attached processes, and other Runtime Viewer instances discovered over Bonjour. This documentation gap makes helper installation look like the step that should populate a list of applications.

## Summary

Add a concise installation subsection at the start of `README.md`'s Getting Started section that identifies GitHub Releases as the official binary source, tells users to install the macOS app from the release archive, and explicitly notes that the project does not publish a Homebrew cask. Keep the existing helper instructions, but clarify that helper registration enables inter-process communication and injection rather than installing the main app or automatically creating connection targets. Add a short first-use explanation of the three supported entry paths already represented in the README and app: browse the local runtime/framework directory, use Attach Process when its SIP prerequisite is met, or select another Runtime Viewer instance discovered on the local network.

## Test plan

- Follow the Getting Started flow from a clean macOS setup and verify that the official Releases link leads to the macOS archive before helper registration is mentioned.
- Verify that the instructions do not imply the helper populates application targets and clearly identify local browsing, explicit process attachment, and Bonjour discovery as separate ways to obtain content.
- Verify that Homebrew is described only as unsupported/unofficial, without supplying or endorsing a cask command the maintainer does not control.
- Check every added relative link and heading anchor in GitHub's rendered Markdown, and confirm the revised text remains consistent with the macOS 15+ requirement and SIP limitation already documented in the README.

Fixes #83
