### PR TITLE
Fix the Relationships description in the v2.1.0 notes

### DIFF
--- a/Changelogs/v2.1.0.md
+++ b/Changelogs/v2.1.0.md
@@ -20,7 +20,7 @@ release-candidate users too, not only to those coming from 2.0.x.
 - **Multi-tab content navigation** with a window tab bar and per-tab history
 - **Generic type specialization** — inspect Swift generics with concrete arguments filled in
 - **Background indexing** — the sidebar is ready when you click into it, not seconds later
-- **Inspector → Relationships** — see who references a type, and what a type depends on
+- **Inspector → Relationships** — a class's subclasses and a protocol's conforming types, gathered across every indexed binary
 - **Batch export** interfaces for multiple images in one pass
 - **Theme settings** with a data-driven color model and a built-in Xcode preset
 - **Jump to Definition** for Swift type references
@@ -48,9 +48,21 @@ interface alongside the original unspecialized form.
   silently producing garbage.
 
 #### Inspector → Relationships
-A new **Relationships** tab sits between *Hierarchy* and *Specialization*. It
-lists inbound references (who uses this type) and outbound references (what
-this type depends on), drawn across every binary the document has loaded.
+A new **Relationships** tab sits between *Hierarchy* and *Specialization*,
+answering the question a single interface listing cannot: what else in the
+loaded binaries builds on this type.
+
+- Select a **class** and it lists that class's direct subclasses.
+- Select a **protocol** and it lists the types that conform to it.
+
+Both are unioned across every indexed image rather than looked up in the image
+that defines the target, so a subclass or conformer living in a different
+binary still shows up. Images that are loaded but not yet indexed contribute
+nothing, so the list fills in as background indexing catches up.
+
+Objective-C and Swift classes and protocols are covered, including classes
+bridged between the two. Other kinds — structs, enums, categories — have no
+relationships to show.
 
 #### Jump to Definition for Swift types
 Command-click a Swift type reference in the content view to navigate to its


### PR DESCRIPTION
The v2.1.0 release notes describe the Relationships tab as listing *inbound
references (who uses this type) and outbound references (what this type
depends on)*. It resolves neither.

`RuntimeRelationships` carries exactly two collections:

```swift
public struct RuntimeRelationships: Hashable, Sendable, Codable {
    public let subclasses: [RuntimeObject]
    public let conformingTypes: [RuntimeObject]
}
```

and `RuntimeRelationshipsResolver.relationships(for:)` fills them for four
kinds only — ObjC/Swift class and ObjC/Swift protocol. A class gets its direct
subclasses, a protocol gets its conforming types, anything else returns
`.empty`. There is no reference analysis anywhere in that path.

The wording originates in the `v2.1.0-beta.2` notes and was copied forward
through `v2.1.0-RC.1` into this release without being checked against the
implementation.

Rewritten to the two lookups that exist, plus the two properties of the result
a user will actually notice: the union runs over every indexed image rather
than the target's defining image, and images still waiting on background
indexing contribute nothing, so the list fills in as indexing catches up.

The same wrong sentence is still in `Changelogs/v2.1.0-beta.2.md` and
`Changelogs/v2.1.0-RC.1.md`, along with the GitHub Release notes those two
tags published. Left alone here — this PR covers the current stable release.