### PR TITLE
release: pull v2.1.0 from the appcast

### DIFF
--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -11,23 +11,6 @@
         <description>RuntimeViewer release feed</description>
         <language>en</language>
         <item>
-            <title>2.1.0</title>
-            <pubDate>Wed, 12 Aug 2026 03:35:55 +0000</pubDate>
-            <sparkle:version>20260812.02.42</sparkle:version>
-            <sparkle:shortVersionString>2.1.0</sparkle:shortVersionString>
-            <sparkle:minimumSystemVersion>15.0</sparkle:minimumSystemVersion>
-            <enclosure url="https://github.com/MxIris-Reverse-Engineering/RuntimeViewer/releases/download/v2.1.0/RuntimeViewer-macOS.zip" length="56688010" type="application/octet-stream" sparkle:edSignature="M9gPE29/5hZ8GIwASww+gDs5O42kVl1mzsCuvaChkimsAiDAL1aIUFJfpwgLrjOP7r0AMNg7hQ1n0Rzfb32tBQ=="/>
-        </item>
-        <item>
-            <title>2.1.0</title>
-            <pubDate>Tue, 11 Aug 2026 14:53:44 +0000</pubDate>
-            <sparkle:channel>beta</sparkle:channel>
-            <sparkle:version>20260811.14.06</sparkle:version>
-            <sparkle:shortVersionString>2.1.0</sparkle:shortVersionString>
-            <sparkle:minimumSystemVersion>15.0</sparkle:minimumSystemVersion>
-            <enclosure url="https://github.com/MxIris-Reverse-Engineering/RuntimeViewer/releases/download/v2.1.0-RC.3/RuntimeViewer-macOS.zip" length="56688095" type="application/octet-stream" sparkle:edSignature="aWR12Pu5BvG7Za/EGCnDAxFSHM915CXMTwctXGo1YiQF5wnChXAEK/jFcBrktJcNVieVIuI7MpLyz3I/f0CeDA=="/>
-        </item>
-        <item>
             <title>2.0.1</title>
             <pubDate>Fri, 01 May 2026 14:50:02 +0000</pubDate>
             <sparkle:version>20260501.14.05</sparkle:version>


### PR DESCRIPTION
## Why

`AttachToProcessViewController` was held as a shared singleton behind `@Dependency(\.attachToProcessViewController)`, so every open document presented the *same* controller instance. When a second document opens Attach To Process, it rebinds a controller the first document is still presenting, and the app crashes.

Both `v2.1.0` and `v2.1.0-RC.3` contain the offending commit (`6849d78`).

## What this does

Removes both `2.1.0` `<item>`s from `docs/appcast.xml` — the stable one and the `beta`-channel one that points at `v2.1.0-RC.3`. The feed now tops out at `2.0.1`, so no client is offered the broken build.

Already done outside this PR, per `Documentations/SparkleRelease.md` → *Rolling back a bad release*:

- `gh release edit v2.1.0 --prerelease` — GitHub now serves `v2.0.1` as latest.

## Follow-up

Sparkle never downgrades, so users who already took `2.1.0` stay on it. They need a `2.1.1` hotfix that makes the controller per-document.