### PR TITLE
fix(attach): give every document its own attach-to-process sheet

### DIFF
--- a/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit/Attach Process/AttachToProcessViewController.swift
+++ b/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit/Attach Process/AttachToProcessViewController.swift
@@ -8,8 +8,6 @@ import DependenciesMacros
 final class AttachToProcessViewController: UXKitViewController<AttachToProcessViewModel> {
 
     override var shouldDisplayCommonLoading: Bool { true }
-
-    fileprivate static let shared = AttachToProcessViewController()
     
     private let pickerViewController: RunningPickerTabViewController
 
@@ -72,11 +70,4 @@ extension AttachToProcessViewController: RunningPickerTabViewController.Delegate
     func runningPickerTabViewControllerWasCancelled(_ viewController: RunningPickerTabViewController) {
         cancelRelay.accept()
     }
-}
-
-// MARK: - Dependencies
-
-extension DependencyValues {
-    @DependencyEntry(liveValue: MainActor.assumeIsolated { AttachToProcessViewController.shared })
-    var attachToProcessViewController: AttachToProcessViewController
 }

--- a/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit/Main/MainCoordinator.swift
+++ b/RuntimeViewerUsingAppKit/RuntimeViewerUsingAppKit/Main/MainCoordinator.swift
@@ -9,7 +9,6 @@ import LateResponders
 typealias MainTransition = SceneTransition<MainWindowController, MainSplitViewController>
 
 final class MainCoordinator: SceneCoordinator<MainRoute, MainTransition>, LateResponderRegistering {
-    @Dependency(\.attachToProcessViewController) private var attachToProcessViewController
 
     let documentState: DocumentState
 
@@ -86,7 +85,7 @@ final class MainCoordinator: SceneCoordinator<MainRoute, MainTransition>, LateRe
             viewController.setupBindings(for: viewModel)
             return .uxPopover(viewController, relativeTo: sender.bounds, of: sender, preferredEdge: .maxY, behavior: .transient, animates: true)
         case .attachToProcess:
-            let viewController = attachToProcessViewController
+            let viewController = AttachToProcessViewController()
             let viewModel = AttachToProcessViewModel(documentState: documentState, router: self)
             viewController.setupBindings(for: viewModel)
             viewController.preferredContentSize = .init(width: 800, height: 600)


### PR DESCRIPTION
## The bug

`AttachToProcessViewController` was held as a shared singleton behind `@Dependency(\.attachToProcessViewController)`. `MainCoordinator` is per-document, so every open document resolved and presented the **same** controller instance.

Attach To Process is presented as a sheet on the document's root window (`.presentOnRoot(_, mode: .asSheet)`), and a view controller can only be presented from one window at a time — opening it in a second document while the first still has it up crashes the app. Even without the crash, `setupBindings(for:)` rebinds the shared instance to the second document's view model, so the first document's sheet would keep driving the wrong document.

## The fix

Construct the controller per presentation, the way every other route in `MainCoordinator` does. The `@DependencyEntry` and the `fileprivate static let shared` go away with it.

## What this gives up

6849d78 introduced the shared instance so the picker would remember the last-selected tab and running row across reopens. That is lost again here. That state belongs in the view model or `AppDefaults`, not in a controller instance shared between documents — worth a follow-up, but not at the price of a crash.

## Related

v2.1.0 has been pulled from the appcast in #95; this is the fix that a 2.1.1 hotfix would carry.